### PR TITLE
feat: add support safe transaction

### DIFF
--- a/src/components/MysqlSafeTransaction.ts
+++ b/src/components/MysqlSafeTransaction.ts
@@ -19,10 +19,7 @@ export class MysqlSafeTransaction {
             return result
         })
 
-        // 统一清理事务更新缓存
-        if (this.cache && clearCacheNsps.length > 0) {
-            await this.cache.mDelete(clearCacheNsps)
-        }
+        if (clearCacheNsps.length > 0) { await this.cache.mDelete(clearCacheNsps) }
         return result
     }
 }

--- a/src/components/MysqlSafeTransaction.ts
+++ b/src/components/MysqlSafeTransaction.ts
@@ -13,7 +13,7 @@ export class MysqlSafeTransaction {
 
     async safeTransaction<T>(handler: (trx: CoaMysql.Transaction) => Promise<T>): Promise<T> {
         let clearCacheNsps: any[] = []
-        const result = await this.bin.io.transaction(async (trx: any) => {
+        const result = await this.bin.io.transaction(async (trx: CoaMysql.Transaction) => {
             trx.__isSafeTransaction = true
             trx.clearCacheNsps = []
 

--- a/src/components/MysqlSafeTransaction.ts
+++ b/src/components/MysqlSafeTransaction.ts
@@ -1,0 +1,28 @@
+import { RedisCache } from "coa-redis"
+import { MysqlBin } from "../libs/MysqlBin"
+import { CoaMysql } from "../typings"
+
+export class MysqlSafeTransaction {
+    private readonly bin: MysqlBin
+    private readonly cache: RedisCache
+
+    constructor(bin: MysqlBin, cache: RedisCache) {
+        this.bin = bin
+        this.cache = cache
+    }
+
+    async safeTransaction<T>(handler: (trx: CoaMysql.Transaction) => Promise<T>): Promise<T> {
+        let clearCacheNsps: any[] = []
+        const result = await this.bin.io.transaction(async (trx: any) => {
+            const result = await handler(trx)
+            clearCacheNsps = trx.clearCacheNsps || []
+            return result
+        })
+
+        // 统一清理事务更新缓存
+        if (this.cache && clearCacheNsps.length > 0) {
+            await this.cache.mDelete(clearCacheNsps)
+        }
+        return result
+    }
+}

--- a/src/components/MysqlSafeTransaction.ts
+++ b/src/components/MysqlSafeTransaction.ts
@@ -14,7 +14,11 @@ export class MysqlSafeTransaction {
     async safeTransaction<T>(handler: (trx: CoaMysql.Transaction) => Promise<T>): Promise<T> {
         let clearCacheNsps: any[] = []
         const result = await this.bin.io.transaction(async (trx: any) => {
+            trx.__isSafeTransaction = true
+            trx.clearCacheNsps = []
+
             const result = await handler(trx)
+
             clearCacheNsps = trx.clearCacheNsps || []
             return result
         })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
-export { CoaMysql } from './typings'
-export { MysqlBin } from './libs/MysqlBin'
-export { MysqlNative } from './services/MysqlNative'
-export { MysqlCache } from './services/MysqlCache'
-export { MysqlUuid } from './components/MysqlUuid'
+export { MysqlSafeTransaction } from './components/MysqlSafeTransaction'
 export { MysqlStorage } from './components/MysqlStorage'
+export { MysqlUuid } from './components/MysqlUuid'
+export { MysqlBin } from './libs/MysqlBin'
+export { MysqlCache } from './services/MysqlCache'
+export { MysqlNative } from './services/MysqlNative'
+export { CoaMysql } from './typings'
+

--- a/src/libs/MysqlBin.ts
+++ b/src/libs/MysqlBin.ts
@@ -1,8 +1,10 @@
 import { echo } from 'coa-echo'
 import { CoaError } from 'coa-error'
-import { Knex } from './Knex'
+import { MysqlCache } from '../services/MysqlCache'
 import { CoaMysql } from '../typings'
+import { Knex } from './Knex'
 
+import { secure } from 'coa-secure'
 export class MysqlBin {
   public io: Knex
   public config: CoaMysql.Config
@@ -29,5 +31,26 @@ export class MysqlBin {
     // 赋值
     this.config = config
     this.io = io
+  }
+
+  async safeTransaction<T>(handler: (trx: CoaMysql.Transaction) => Promise<T>): Promise<T> {
+    let cacheTasks: Array<{ model: MysqlCache<any>, ids: string[], dataList: any[] }> = []
+
+    const result = await this.io.transaction(async (trx: any) => {
+      trx.registerCacheClear = (model: MysqlCache<any>, ids: string[], dataList: any[]) => {
+        cacheTasks.push({ model, ids, dataList })
+        trx.id ||= secure.id25(`${Date.now()}-${model}`)
+      }
+
+      return await handler(trx)
+    })
+
+    for (const task of cacheTasks) {
+      await task.model.deleteCache(task.ids, task.dataList)
+    }
+    // 初始数组 减少trx未及时销毁时的内存占用
+    cacheTasks = []
+
+    return result
   }
 }

--- a/src/libs/MysqlBin.ts
+++ b/src/libs/MysqlBin.ts
@@ -1,10 +1,9 @@
 import { echo } from 'coa-echo'
 import { CoaError } from 'coa-error'
+import { secure } from 'coa-secure'
 import { MysqlCache } from '../services/MysqlCache'
 import { CoaMysql } from '../typings'
 import { Knex } from './Knex'
-
-import { secure } from 'coa-secure'
 export class MysqlBin {
   public io: Knex
   public config: CoaMysql.Config
@@ -41,7 +40,6 @@ export class MysqlBin {
         cacheTasks.push({ model, ids, dataList })
         trx.id ||= secure.id25(`${Date.now()}-${model}`)
       }
-
       return await handler(trx)
     })
 

--- a/src/libs/MysqlBin.ts
+++ b/src/libs/MysqlBin.ts
@@ -1,6 +1,5 @@
 import { echo } from 'coa-echo'
 import { CoaError } from 'coa-error'
-import { secure } from 'coa-secure'
 import { MysqlCache } from '../services/MysqlCache'
 import { CoaMysql } from '../typings'
 import { Knex } from './Knex'
@@ -33,11 +32,9 @@ export class MysqlBin {
   }
 
   async safeTransaction<T>(handler: (trx: CoaMysql.Transaction) => Promise<T>): Promise<T> {
-
     let cacheTasks = [] as Array<{ model: MysqlCache<any>, ids: string[], dataList: any[] }>
 
     const result = await this.io.transaction(async (trx: any) => {
-      trx.id ||= secure.id25(`${Date.now()}-${Math.floor(Math.random() * 1e6).toString().padStart(6, '0')}`)
       //  收集事务更新缓存数据
       trx.trxUpdateCacheTaskList = async (model: MysqlCache<any>, ids: string[], dataList: any[]) => {
         cacheTasks.push({ model, ids, dataList })

--- a/src/libs/MysqlBin.ts
+++ b/src/libs/MysqlBin.ts
@@ -33,21 +33,32 @@ export class MysqlBin {
   }
 
   async safeTransaction<T>(handler: (trx: CoaMysql.Transaction) => Promise<T>): Promise<T> {
-    let cacheTasks: Array<{ model: MysqlCache<any>, ids: string[], dataList: any[] }> = []
+
+    let cacheTasks = {
+      trxUpdateCacheTaskList: [] as Array<{ model: MysqlCache<any>, ids: string[], dataList: any[] }>,
+      trxRaeadCacheNspsList: [] as Array<{ model: MysqlCache<any>, nsp: string }>
+    };
 
     const result = await this.io.transaction(async (trx: any) => {
-      trx.registerCacheClear = (model: MysqlCache<any>, ids: string[], dataList: any[]) => {
-        cacheTasks.push({ model, ids, dataList })
-        trx.id ||= secure.id25(`${Date.now()}-${model}`)
+      trx.id ||= secure.id25(`${Date.now()}-${Math.floor(Math.random() * 1e6).toString().padStart(6, '0')}`)
+      trx.trxUpdateCacheTaskList = (model: MysqlCache<any>, ids: string[], dataList: any[]) => {
+        cacheTasks.trxUpdateCacheTaskList.push({ model, ids, dataList })
+      }
+      trx.trxRaeadCacheNspsList = (model: MysqlCache<any>, nsp: string) => {
+        cacheTasks.trxRaeadCacheNspsList.push({ model, nsp })
       }
       return await handler(trx)
     })
 
-    for (const task of cacheTasks) {
+    for (const task of cacheTasks.trxUpdateCacheTaskList) {
       await task.model.deleteCache(task.ids, task.dataList)
     }
+
+    for (const readCacheNsp of cacheTasks.trxRaeadCacheNspsList) {
+      await readCacheNsp.model.redisCache.clear(readCacheNsp.nsp)
+    }
     // 初始数组 减少trx未及时销毁时的内存占用
-    cacheTasks = []
+    cacheTasks = { trxUpdateCacheTaskList: [], trxRaeadCacheNspsList: [] }
 
     return result
   }

--- a/src/libs/MysqlBin.ts
+++ b/src/libs/MysqlBin.ts
@@ -1,6 +1,5 @@
 import { echo } from 'coa-echo'
 import { CoaError } from 'coa-error'
-import { MysqlCache } from '../services/MysqlCache'
 import { CoaMysql } from '../typings'
 import { Knex } from './Knex'
 export class MysqlBin {
@@ -29,26 +28,5 @@ export class MysqlBin {
     // 赋值
     this.config = config
     this.io = io
-  }
-
-  async safeTransaction<T>(handler: (trx: CoaMysql.Transaction) => Promise<T>): Promise<T> {
-    let cacheTasks = [] as Array<{ model: MysqlCache<any>, ids: string[], dataList: any[] }>
-
-    const result = await this.io.transaction(async (trx: any) => {
-      //  收集事务更新缓存数据
-      trx.trxUpdateCacheTaskList = async (model: MysqlCache<any>, ids: string[], dataList: any[]) => {
-        cacheTasks.push({ model, ids, dataList })
-      }
-      return await handler(trx)
-    })
-    // 统一清理事务更新缓存
-    for (const task of cacheTasks) {
-      await task.model.deleteCache(task.ids, task.dataList)
-    }
-
-    // 初始数组 减少trx未及时销毁时的内存占用
-    cacheTasks = []
-
-    return result
   }
 }

--- a/src/libs/MysqlBin.ts
+++ b/src/libs/MysqlBin.ts
@@ -34,31 +34,23 @@ export class MysqlBin {
 
   async safeTransaction<T>(handler: (trx: CoaMysql.Transaction) => Promise<T>): Promise<T> {
 
-    let cacheTasks = {
-      trxUpdateCacheTaskList: [] as Array<{ model: MysqlCache<any>, ids: string[], dataList: any[] }>,
-      trxRaeadCacheNspsList: [] as Array<{ model: MysqlCache<any>, nsp: string }>
-    };
+    let cacheTasks = [] as Array<{ model: MysqlCache<any>, ids: string[], dataList: any[] }>
 
     const result = await this.io.transaction(async (trx: any) => {
       trx.id ||= secure.id25(`${Date.now()}-${Math.floor(Math.random() * 1e6).toString().padStart(6, '0')}`)
-      trx.trxUpdateCacheTaskList = (model: MysqlCache<any>, ids: string[], dataList: any[]) => {
-        cacheTasks.trxUpdateCacheTaskList.push({ model, ids, dataList })
-      }
-      trx.trxRaeadCacheNspsList = (model: MysqlCache<any>, nsp: string) => {
-        cacheTasks.trxRaeadCacheNspsList.push({ model, nsp })
+      //  收集事务更新缓存数据
+      trx.trxUpdateCacheTaskList = async (model: MysqlCache<any>, ids: string[], dataList: any[]) => {
+        cacheTasks.push({ model, ids, dataList })
       }
       return await handler(trx)
     })
-
-    for (const task of cacheTasks.trxUpdateCacheTaskList) {
+    // 统一清理事务更新缓存
+    for (const task of cacheTasks) {
       await task.model.deleteCache(task.ids, task.dataList)
     }
 
-    for (const readCacheNsp of cacheTasks.trxRaeadCacheNspsList) {
-      await readCacheNsp.model.redisCache.clear(readCacheNsp.nsp)
-    }
     // 初始数组 减少trx未及时销毁时的内存占用
-    cacheTasks = { trxUpdateCacheTaskList: [], trxRaeadCacheNspsList: [] }
+    cacheTasks = []
 
     return result
   }

--- a/src/services/MysqlCache.ts
+++ b/src/services/MysqlCache.ts
@@ -70,11 +70,11 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
   }
 
   async getIdBy(field: string, value: string | number, trx?: CoaMysql.Transaction) {
-    return trx ? await super.getIdBy(field, value, trx) : await this.redisCache.warp(this.getCacheNsp('index', field), '' + value, async () => await super.getIdBy(field, value, trx))
+    return (trx as any).__isSafeTransaction ? await super.getIdBy(field, value, trx) : await this.redisCache.warp(this.getCacheNsp('index', field), '' + value, async () => await super.getIdBy(field, value, trx))
   }
 
   async mGetByIds(ids: string[], pick = this.pick, trx?: CoaMysql.Transaction, ms = this.ms, force = false) {
-    const result = trx ? await super.mGetByIds(ids, this.columns, trx) : await this.redisCache.mWarp(this.getCacheNsp('id'), ids, async ids => await super.mGetByIds(ids, this.columns, trx), ms, force)
+    const result = (trx as any).__isSafeTransaction ? await super.mGetByIds(ids, this.columns, trx) : await this.redisCache.mWarp(this.getCacheNsp('id'), ids, async ids => await super.mGetByIds(ids, this.columns, trx), ms, force)
     _.forEach(result, (v, k) => {
       result[k] = this.pickResult(v, pick)
     })
@@ -88,23 +88,23 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
 
   protected async findListCount(finger: Array<CoaMysql.Dic<any>>, query: CoaMysql.Query, trx?: CoaMysql.Transaction) {
     const cacheId = 'list-count:' + secure.sha1($.sortQueryString(...finger))
-    return trx ? await super.selectListCount(query, trx) : await this.redisCache.warp(this.getCacheNsp('data'), cacheId, async () => await super.selectListCount(query, trx))
+    return (trx as any)?.__isSafeTransaction ? await super.selectListCount(query, trx) : await this.redisCache.warp(this.getCacheNsp('data'), cacheId, async () => await super.selectListCount(query, trx))
   }
 
   protected async findIdList(finger: Array<CoaMysql.Dic<any>>, query: CoaMysql.Query, trx?: CoaMysql.Transaction) {
     const cacheId = 'list:' + secure.sha1($.sortQueryString(...finger))
-    return trx ? await super.selectIdList(query, trx) : await this.redisCache.warp(this.getCacheNsp('data'), cacheId, async () => await super.selectIdList(query, trx))
+    return (trx as any)?.__isSafeTransaction ? await super.selectIdList(query, trx) : await this.redisCache.warp(this.getCacheNsp('data'), cacheId, async () => await super.selectIdList(query, trx))
   }
 
   protected async findIdSortList(finger: Array<CoaMysql.Dic<any>>, pager: CoaMysql.Pager, query: CoaMysql.Query, trx?: CoaMysql.Transaction) {
     const cacheId = `sort-list:${pager.rows}:${pager.last}:` + secure.sha1($.sortQueryString(...finger))
-    return trx ? await super.selectIdSortList(pager, query, trx) : await this.redisCache.warp(this.getCacheNsp('data'), cacheId, async () => await super.selectIdSortList(pager, query, trx))
+    return (trx as any)?.__isSafeTransaction ? await super.selectIdSortList(pager, query, trx) : await this.redisCache.warp(this.getCacheNsp('data'), cacheId, async () => await super.selectIdSortList(pager, query, trx))
   }
 
   protected async findIdViewList(finger: Array<CoaMysql.Dic<any>>, pager: CoaMysql.Pager, query: CoaMysql.Query, trx?: CoaMysql.Transaction) {
     const cacheId = `view-list:${pager.rows}:${pager.page}:` + secure.sha1($.sortQueryString(...finger))
     const count = await this.findListCount(finger, query, trx)
-    return trx ? await super.selectIdViewList(pager, query, trx, count) : await this.redisCache.warp(this.getCacheNsp('data'), cacheId, async () => await super.selectIdViewList(pager, query, trx, count))
+    return (trx as any)?.__isSafeTransaction ? await super.selectIdViewList(pager, query, trx, count) : await this.redisCache.warp(this.getCacheNsp('data'), cacheId, async () => await super.selectIdViewList(pager, query, trx, count))
   }
 
   protected async mGetCountBy(field: string, ids: string[], trx?: CoaMysql.Transaction) {
@@ -114,7 +114,7 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
       _.forEach(rows, ({ id, count }) => (result[id] = count))
       return result
     }
-    const result = trx ? await queryFunction() : await this.redisCache.mWarp(this.getCacheNsp('count', field), ids, queryFunction)
+    const result = (trx as any)?.__isSafeTransaction ? await queryFunction() : await this.redisCache.mWarp(this.getCacheNsp('count', field), ids, queryFunction)
     return result
   }
 
@@ -125,7 +125,7 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
       const rows = await qb
       return (rows[0]?.count as number) || 0
     }
-    const result = trx ? await queryFunction() : await this.redisCache.warp(this.getCacheNsp('count', field), value, queryFunction)
+    const result = (trx as any)?.__isSafeTransaction ? await queryFunction() : await this.redisCache.warp(this.getCacheNsp('count', field), value, queryFunction)
     return result
   }
 
@@ -153,12 +153,9 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
   }
 
   async deleteCache(ids: string[], dataList: Array<CoaMysql.SafePartial<Scheme>>, trx?: CoaMysql.Transaction) {
-    if (trx && !(trx as any).clearCacheNsps) {
-      (trx as any).clearCacheNsps = [] as CoaRedis.CacheDelete[]
-    }
-    if (trx && (trx as any).clearCacheNsps) {
-      (trx as any).clearCacheNsps.push([this.getCacheNsp('id'), ids]);
-      (trx as any).clearCacheNsps.push([this.getCacheNsp('data'), []])
+    if ((trx as any)?.__isSafeTransaction) {
+      (trx as any)?.clearCacheNsps.push([this.getCacheNsp('id'), ids]);
+      (trx as any)?.clearCacheNsps.push([this.getCacheNsp('data'), []])
     }
     const deleteIds = [] as CoaRedis.CacheDelete[]
     deleteIds.push([this.getCacheNsp('id'), ids])
@@ -173,9 +170,11 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
           data?.[key] && ids.push(data[key])
         })
         ids.push(...keys.slice(1))
-        trx ? (ids.length && (trx as any).clearCacheNsps.push([this.getCacheNsp(name, key), ids])) : (ids.length && deleteIds.push([this.getCacheNsp(name, key), ids]))
+        if (ids.length) {
+          ((trx as any)?.__isSafeTransaction) ? (trx as any)?.clearCacheNsps.push([this.getCacheNsp(name, key), ids]) : deleteIds.push([this.getCacheNsp(name, key), ids])
+        }
       })
     })
-    if (!trx) await this.redisCache.mDelete(deleteIds)
+    if ((!trx as any).__isSafeTransaction) await this.redisCache.mDelete(deleteIds)
   }
 }

--- a/src/services/MysqlCache.ts
+++ b/src/services/MysqlCache.ts
@@ -1,3 +1,4 @@
+import { echo } from 'coa-echo'
 import { CoaError } from 'coa-error'
 import { $, _ } from 'coa-helper'
 import { CoaRedis, RedisCache } from 'coa-redis'
@@ -5,7 +6,6 @@ import { secure } from 'coa-secure'
 import { MysqlBin } from '../libs/MysqlBin'
 import { CoaMysql } from '../typings'
 import { MysqlNative } from './MysqlNative'
-
 export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
   redisCache: RedisCache
 
@@ -16,48 +16,62 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
 
   async insert(data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const id = await super.insert(data, trx)
-    await this.deleteCache([id], [data])
+    if (id) {
+      (trx && (trx as any).registerCacheClear) ? (trx as any).registerCacheClear(this, [id], data) : await this.deleteCache([id], [data])
+    }
     return id
   }
 
   async mInsert(dataList: Array<CoaMysql.SafePartial<Scheme>>, trx?: CoaMysql.Transaction) {
     const ids = await super.mInsert(dataList, trx)
-    await this.deleteCache(ids, dataList)
+    if (ids) {
+      (trx && (trx as any).registerCacheClear) ? (trx as any).registerCacheClear(this, ids, dataList) : await this.deleteCache(ids, dataList)
+    }
     return ids
   }
 
   async updateById(id: string, data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList([id], data, trx)
     const result = await super.updateById(id, data, trx)
-    if (result) await this.deleteCache([id], dataList)
+    if (result) {
+      (trx && (trx as any).registerCacheClear) ? (trx as any).registerCacheClear(this, [id], dataList) : await this.deleteCache([id], dataList)
+    }
     return result
   }
 
   async updateByIds(ids: string[], data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList(ids, data, trx)
     const result = await super.updateByIds(ids, data, trx)
-    if (result) await this.deleteCache(ids, dataList)
+    if (result) {
+      (trx && (trx as any).registerCacheClear) ? (trx as any).registerCacheClear(this, ids, dataList) : await this.deleteCache(ids, dataList)
+    }
     return result
   }
 
   async updateForQueryById(id: string, query: CoaMysql.Query, data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList([id], data, trx)
     const result = await super.updateForQueryById(id, query, data, trx)
-    if (result) await this.deleteCache([id], dataList)
+    if (result) {
+      (trx && (trx as any).registerCacheClear) ? (trx as any).registerCacheClear(this, [id], dataList) : await this.deleteCache([id], dataList)
+    }
     return result
   }
 
   async upsertById(id: string, data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList([id], data, trx)
     const result = await super.upsertById(id, data, trx)
-    await this.deleteCache([id], dataList)
+    if (result) {
+      (trx && (trx as any).registerCacheClear) ? (trx as any).registerCacheClear(this, [id], dataList) : await this.deleteCache([id], dataList)
+    }
     return result
   }
 
   async deleteByIds(ids: string[], trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList(ids, undefined, trx)
     const result = await super.deleteByIds(ids, trx)
-    if (result) await this.deleteCache(ids, dataList)
+    if (result) {
+      (trx && (trx as any).registerCacheClear) ? (trx as any).registerCacheClear(this, ids, dataList) : await this.deleteCache(ids, dataList)
+    }
     return result
   }
 
@@ -66,16 +80,19 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
   }
 
   async getById(id: string, pick = this.columns, trx?: CoaMysql.Transaction, ms = this.ms, force = false) {
-    const result = await this.redisCache.warp(this.getCacheNsp('id'), id, async () => await super.getById(id, this.columns, trx), ms, force)
+    const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'id') : this.getCacheNsp('id')
+    const result = await this.redisCache.warp(cacheNsp, id, async () => await super.getById(id, this.columns, trx), ms, force)
     return this.pickResult(result, pick)
   }
 
   async getIdBy(field: string, value: string | number, trx?: CoaMysql.Transaction) {
-    return await this.redisCache.warp(this.getCacheNsp('index', field), '' + value, async () => await super.getIdBy(field, value, trx))
+    const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'index', field) : this.getCacheNsp('index', field)
+    return await this.redisCache.warp(cacheNsp, '' + value, async () => await super.getIdBy(field, value, trx))
   }
 
   async mGetByIds(ids: string[], pick = this.pick, trx?: CoaMysql.Transaction, ms = this.ms, force = false) {
-    const result = await this.redisCache.mWarp(this.getCacheNsp('id'), ids, async ids => await super.mGetByIds(ids, this.columns, trx), ms, force)
+    const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'id') : this.getCacheNsp('id')
+    const result = await this.redisCache.mWarp(cacheNsp, ids, async ids => await super.mGetByIds(ids, this.columns, trx), ms, force)
     _.forEach(result, (v, k) => {
       result[k] = this.pickResult(v, pick)
     })
@@ -88,32 +105,37 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
   }
 
   protected async findListCount(finger: Array<CoaMysql.Dic<any>>, query: CoaMysql.Query, trx?: CoaMysql.Transaction) {
-    const cacheNsp = this.getCacheNsp('data')
+    // const cacheNsp = this.getCacheNsp('data')
+    const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'data') : this.getCacheNsp('data')
     const cacheId = 'list-count:' + secure.sha1($.sortQueryString(...finger))
     return await this.redisCache.warp(cacheNsp, cacheId, async () => await super.selectListCount(query, trx))
   }
 
   protected async findIdList(finger: Array<CoaMysql.Dic<any>>, query: CoaMysql.Query, trx?: CoaMysql.Transaction) {
-    const cacheNsp = this.getCacheNsp('data')
+    // const cacheNsp = this.getCacheNsp('data')
+    const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'data') : this.getCacheNsp('data')
     const cacheId = 'list:' + secure.sha1($.sortQueryString(...finger))
     return await this.redisCache.warp(cacheNsp, cacheId, async () => await super.selectIdList(query, trx))
   }
 
   protected async findIdSortList(finger: Array<CoaMysql.Dic<any>>, pager: CoaMysql.Pager, query: CoaMysql.Query, trx?: CoaMysql.Transaction) {
-    const cacheNsp = this.getCacheNsp('data')
+    // const cacheNsp = this.getCacheNsp('data')
+    const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'data') : this.getCacheNsp('data')
     const cacheId = `sort-list:${pager.rows}:${pager.last}:` + secure.sha1($.sortQueryString(...finger))
     return await this.redisCache.warp(cacheNsp, cacheId, async () => await super.selectIdSortList(pager, query, trx))
   }
 
   protected async findIdViewList(finger: Array<CoaMysql.Dic<any>>, pager: CoaMysql.Pager, query: CoaMysql.Query, trx?: CoaMysql.Transaction) {
-    const cacheNsp = this.getCacheNsp('data')
+    // const cacheNsp = this.getCacheNsp('data')
+    const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'data') : this.getCacheNsp('data')
     const cacheId = `view-list:${pager.rows}:${pager.page}:` + secure.sha1($.sortQueryString(...finger))
     const count = await this.findListCount(finger, query, trx)
     return await this.redisCache.warp(cacheNsp, cacheId, async () => await super.selectIdViewList(pager, query, trx, count))
   }
 
   protected async mGetCountBy(field: string, ids: string[], trx?: CoaMysql.Transaction) {
-    const cacheNsp = this.getCacheNsp('count', field)
+    // const cacheNsp = this.getCacheNsp('count', field)
+    const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'count', field) : this.getCacheNsp('count', field)
     return await this.redisCache.mWarp(cacheNsp, ids, async ids => {
       const rows = (await this.table(trx).select({ id: field }).count({ count: this.key }).whereIn(field, ids).groupBy(field)) as any[]
       const result: CoaMysql.Dic<number> = {}
@@ -123,7 +145,8 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
   }
 
   protected async getCountBy(field: string, value: string, query?: CoaMysql.Query, trx?: CoaMysql.Transaction) {
-    const cacheNsp = this.getCacheNsp('count', field)
+    // const cacheNsp = this.getCacheNsp('count', field)
+    const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'count', field) : this.getCacheNsp('count', field)
     return await this.redisCache.warp(cacheNsp, value, async () => {
       const qb = this.table(trx).count({ count: this.key })
       query ? query(qb) : qb.where(field, value)
@@ -141,6 +164,12 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
     return this.system + ':' + this.name + ':' + nsp.join(':')
   }
 
+  // 为每个事务维护独立的缓存空间
+  protected getTransactionCacheNsp(trx?: CoaMysql.Transaction, ...nsp: string[]) {
+    const base = this.system + ':' + this.name + ':' + nsp.join(':')
+    return trx && (trx as any).id ? `${base}:trx:${(trx as any).id}` : base
+  }
+
   protected async getCacheChangedDataList(ids: string[], data?: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     let has = true
     const resultList = [] as Array<CoaMysql.SafePartial<Scheme>>
@@ -155,7 +184,7 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
     return resultList
   }
 
-  protected async deleteCache(ids: string[], dataList: Array<CoaMysql.SafePartial<Scheme>>) {
+  async deleteCache(ids: string[], dataList: Array<CoaMysql.SafePartial<Scheme>>) {
     const deleteIds = [] as CoaRedis.CacheDelete[]
     deleteIds.push([this.getCacheNsp('id'), ids])
     deleteIds.push([this.getCacheNsp('data'), []])
@@ -173,5 +202,7 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
       })
     })
     await this.redisCache.mDelete(deleteIds)
+    echo.grey(`REDIS:DeleteIds${deleteIds};`)
+
   }
 }

--- a/src/services/MysqlCache.ts
+++ b/src/services/MysqlCache.ts
@@ -175,6 +175,6 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
         }
       })
     })
-    if ((!trx as any).__isSafeTransaction) await this.redisCache.mDelete(deleteIds)
+    if (!(trx as any)?.__isSafeTransaction) await this.redisCache.mDelete(deleteIds)
   }
 }

--- a/src/services/MysqlCache.ts
+++ b/src/services/MysqlCache.ts
@@ -16,53 +16,41 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
 
   async insert(data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const id = await super.insert(data, trx)
-    if (id) {
-      (trx && (trx as any).trxUpdateCacheTaskList) ? (trx as any).trxUpdateCacheTaskList(this, [id], [data]) : await this.deleteCache([id], [data])
-    }
+    trx && (trx as any).trxUpdateCacheTaskList ? await (trx as any).trxUpdateCacheTaskList(this, [id], [data]) : await this.deleteCache([id], [data])
     return id
   }
 
   async mInsert(dataList: Array<CoaMysql.SafePartial<Scheme>>, trx?: CoaMysql.Transaction) {
     const ids = await super.mInsert(dataList, trx)
-    if (ids) {
-      (trx && (trx as any).trxUpdateCacheTaskList) ? (trx as any).trxUpdateCacheTaskList(this, ids, dataList) : await this.deleteCache(ids, dataList)
-    }
+    trx && (trx as any).trxUpdateCacheTaskList ? await (trx as any).trxUpdateCacheTaskList(this, ids, dataList) : await this.deleteCache(ids, dataList)
     return ids
   }
 
   async updateById(id: string, data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList([id], data, trx)
     const result = await super.updateById(id, data, trx)
-    if (result) {
-      (trx && (trx as any).trxUpdateCacheTaskList) ? (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList)
-    }
+    trx && (trx as any).trxUpdateCacheTaskList ? await (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList)
     return result
   }
 
   async updateByIds(ids: string[], data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList(ids, data, trx)
     const result = await super.updateByIds(ids, data, trx)
-    if (result) {
-      (trx && (trx as any).trxUpdateCacheTaskList) ? (trx as any).trxUpdateCacheTaskList(this, ids, dataList) : await this.deleteCache(ids, dataList)
-    }
+    trx && (trx as any).trxUpdateCacheTaskList ? await (trx as any).trxUpdateCacheTaskList(this, ids, dataList) : await this.deleteCache(ids, dataList)
     return result
   }
 
   async updateForQueryById(id: string, query: CoaMysql.Query, data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList([id], data, trx)
     const result = await super.updateForQueryById(id, query, data, trx)
-    if (result) {
-      (trx && (trx as any).trxUpdateCacheTaskList) ? (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList)
-    }
+    trx && (trx as any).trxUpdateCacheTaskList ? await (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList)
     return result
   }
 
   async upsertById(id: string, data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList([id], data, trx)
     const result = await super.upsertById(id, data, trx)
-    if (result) {
-      (trx && (trx as any).trxUpdateCacheTaskList) ? (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList)
-    }
+    trx && (trx as any).trxUpdateCacheTaskList ? await (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList)
     return result
   }
 
@@ -70,7 +58,7 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
     const dataList = await this.getCacheChangedDataList(ids, undefined, trx)
     const result = await super.deleteByIds(ids, trx)
     if (result) {
-      (trx && (trx as any).trxUpdateCacheTaskList) ? (trx as any).trxUpdateCacheTaskList(this, ids, dataList) : await this.deleteCache(ids, dataList)
+      (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, ids, dataList) : await this.deleteCache(ids, dataList)
     }
     return result
   }
@@ -81,21 +69,18 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
 
   async getById(id: string, pick = this.columns, trx?: CoaMysql.Transaction, ms = this.ms, force = false) {
     const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'id') : this.getCacheNsp('id')
-    trx && (trx as any).trxRaeadCacheNspsList(this, cacheNsp)
-    const result = await this.redisCache.warp(cacheNsp, id, async () => await super.getById(id, this.columns, trx), ms, force)
+    const result = trx ? await super.getById(id, this.columns, trx) : await this.redisCache.warp(cacheNsp, id, async () => await super.getById(id, this.columns, trx), ms, force)
     return this.pickResult(result, pick)
   }
 
   async getIdBy(field: string, value: string | number, trx?: CoaMysql.Transaction) {
     const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'index', field) : this.getCacheNsp('index', field)
-    trx && (trx as any).trxRaeadCacheNspsList(this, cacheNsp)
-    return await this.redisCache.warp(cacheNsp, '' + value, async () => await super.getIdBy(field, value, trx))
+    return trx ? await super.getIdBy(field, value, trx) : await this.redisCache.warp(cacheNsp, '' + value, async () => await super.getIdBy(field, value, trx))
   }
 
   async mGetByIds(ids: string[], pick = this.pick, trx?: CoaMysql.Transaction, ms = this.ms, force = false) {
     const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'id') : this.getCacheNsp('id')
-    trx && (trx as any).trxRaeadCacheNspsList(this, cacheNsp)
-    const result = await this.redisCache.mWarp(cacheNsp, ids, async ids => await super.mGetByIds(ids, this.columns, trx), ms, force)
+    const result = trx ? await super.mGetByIds(ids, this.columns, trx) : await this.redisCache.mWarp(cacheNsp, ids, async ids => await super.mGetByIds(ids, this.columns, trx), ms, force)
     _.forEach(result, (v, k) => {
       result[k] = this.pickResult(v, pick)
     })
@@ -109,53 +94,61 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
 
   protected async findListCount(finger: Array<CoaMysql.Dic<any>>, query: CoaMysql.Query, trx?: CoaMysql.Transaction) {
     const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'data') : this.getCacheNsp('data')
-    trx && (trx as any).trxRaeadCacheNspsList(this, cacheNsp)
     const cacheId = 'list-count:' + secure.sha1($.sortQueryString(...finger))
-    return await this.redisCache.warp(cacheNsp, cacheId, async () => await super.selectListCount(query, trx))
+    return trx ? await super.selectListCount(query, trx) : await this.redisCache.warp(cacheNsp, cacheId, async () => await super.selectListCount(query, trx))
   }
 
   protected async findIdList(finger: Array<CoaMysql.Dic<any>>, query: CoaMysql.Query, trx?: CoaMysql.Transaction) {
     const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'data') : this.getCacheNsp('data')
-    trx && (trx as any).trxRaeadCacheNspsList(this, cacheNsp)
     const cacheId = 'list:' + secure.sha1($.sortQueryString(...finger))
-    return await this.redisCache.warp(cacheNsp, cacheId, async () => await super.selectIdList(query, trx))
+    return trx ? await super.selectIdList(query, trx) : await this.redisCache.warp(cacheNsp, cacheId, async () => await super.selectIdList(query, trx))
   }
 
   protected async findIdSortList(finger: Array<CoaMysql.Dic<any>>, pager: CoaMysql.Pager, query: CoaMysql.Query, trx?: CoaMysql.Transaction) {
     const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'data') : this.getCacheNsp('data')
-    trx && (trx as any).trxRaeadCacheNspsList(this, cacheNsp)
     const cacheId = `sort-list:${pager.rows}:${pager.last}:` + secure.sha1($.sortQueryString(...finger))
-    return await this.redisCache.warp(cacheNsp, cacheId, async () => await super.selectIdSortList(pager, query, trx))
+    return trx ? await super.selectIdSortList(pager, query, trx) : await this.redisCache.warp(cacheNsp, cacheId, async () => await super.selectIdSortList(pager, query, trx))
   }
 
   protected async findIdViewList(finger: Array<CoaMysql.Dic<any>>, pager: CoaMysql.Pager, query: CoaMysql.Query, trx?: CoaMysql.Transaction) {
     const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'data') : this.getCacheNsp('data')
-    trx && (trx as any).trxRaeadCacheNspsList(this, cacheNsp)
     const cacheId = `view-list:${pager.rows}:${pager.page}:` + secure.sha1($.sortQueryString(...finger))
     const count = await this.findListCount(finger, query, trx)
-    return await this.redisCache.warp(cacheNsp, cacheId, async () => await super.selectIdViewList(pager, query, trx, count))
+    return trx ? await super.selectIdViewList(pager, query, trx, count) : await this.redisCache.warp(cacheNsp, cacheId, async () => await super.selectIdViewList(pager, query, trx, count))
   }
 
   protected async mGetCountBy(field: string, ids: string[], trx?: CoaMysql.Transaction) {
-    const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'count', field) : this.getCacheNsp('count', field)
-    trx && (trx as any).trxRaeadCacheNspsList(this, cacheNsp)
-    return await this.redisCache.mWarp(cacheNsp, ids, async ids => {
+    const queryFunction = async () => {
       const rows = (await this.table(trx).select({ id: field }).count({ count: this.key }).whereIn(field, ids).groupBy(field)) as any[]
       const result: CoaMysql.Dic<number> = {}
       _.forEach(rows, ({ id, count }) => (result[id] = count))
       return result
-    })
+    }
+
+    if (trx) {
+      return await queryFunction()
+    } else {
+      const cacheNsp = this.getCacheNsp('count', field)
+      return await this.redisCache.mWarp(cacheNsp, ids, queryFunction)
+    }
   }
 
   protected async getCountBy(field: string, value: string, query?: CoaMysql.Query, trx?: CoaMysql.Transaction) {
-    const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'count', field) : this.getCacheNsp('count', field)
-    trx && (trx as any).trxRaeadCacheNspsList(this, cacheNsp)
-    return await this.redisCache.warp(cacheNsp, value, async () => {
+    const queryFunction = async () => {
       const qb = this.table(trx).count({ count: this.key })
       query ? query(qb) : qb.where(field, value)
       const rows = await qb
       return (rows[0]?.count as number) || 0
-    })
+    }
+
+    if (trx) {
+      // 事务内直接查询数据库，不走缓存
+      return await queryFunction()
+    } else {
+      // 非事务走缓存
+      const cacheNsp = this.getCacheNsp('count', field)
+      return await this.redisCache.warp(cacheNsp, value, queryFunction)
+    }
   }
 
   protected pickResult<T>(data: T, pick: string[]) {

--- a/src/services/MysqlCache.ts
+++ b/src/services/MysqlCache.ts
@@ -15,48 +15,48 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
 
   async insert(data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const id = await super.insert(data, trx);
-    (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, [id], [data]) : await this.deleteCache([id], [data])
+    await this.deleteCache([id], [data], trx)
     return id
   }
 
   async mInsert(dataList: Array<CoaMysql.SafePartial<Scheme>>, trx?: CoaMysql.Transaction) {
     const ids = await super.mInsert(dataList, trx);
-    (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, ids, dataList) : await this.deleteCache(ids, dataList)
+    await this.deleteCache(ids, dataList, trx)
     return ids
   }
 
   async updateById(id: string, data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList([id], data, trx)
-    const result = await super.updateById(id, data, trx);
-    if (result) { (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList) }
+    const result = await super.updateById(id, data, trx)
+    await this.deleteCache([id], dataList, trx)
     return result
   }
 
   async updateByIds(ids: string[], data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList(ids, data, trx)
     const result = await super.updateByIds(ids, data, trx);
-    if (result) { (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, ids, dataList) : await this.deleteCache(ids, dataList) }
+    await this.deleteCache(ids, dataList, trx)
     return result
   }
 
   async updateForQueryById(id: string, query: CoaMysql.Query, data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList([id], data, trx)
     const result = await super.updateForQueryById(id, query, data, trx);
-    if (result) { (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList) }
+    await this.deleteCache([id], dataList, trx)
     return result
   }
 
   async upsertById(id: string, data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList([id], data, trx)
     const result = await super.upsertById(id, data, trx);
-    (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList)
+    await this.deleteCache([id], dataList, trx)
     return result
   }
 
   async deleteByIds(ids: string[], trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList(ids, undefined, trx)
     const result = await super.deleteByIds(ids, trx);
-    if (result) { (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, ids, dataList) : await this.deleteCache(ids, dataList) }
+    await this.deleteCache(ids, dataList, trx)
     return result
   }
 
@@ -152,7 +152,12 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
     return resultList
   }
 
-  async deleteCache(ids: string[], dataList: Array<CoaMysql.SafePartial<Scheme>>) {
+  async deleteCache(ids: string[], dataList: Array<CoaMysql.SafePartial<Scheme>>, trx?: CoaMysql.Transaction) {
+    if (trx && !(trx as any).clearCacheNsps) {
+      (trx as any).clearCacheNsps = [] as any
+      (trx as any).clearCacheNsps.push([this.getCacheNsp('id'), ids]);
+      (trx as any).clearCacheNsps.push([this.getCacheNsp('data'), []])
+    }
     const deleteIds = [] as CoaRedis.CacheDelete[]
     deleteIds.push([this.getCacheNsp('id'), ids])
     deleteIds.push([this.getCacheNsp('data'), []])
@@ -166,9 +171,9 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
           data?.[key] && ids.push(data[key])
         })
         ids.push(...keys.slice(1))
-        ids.length && deleteIds.push([this.getCacheNsp(name, key), ids])
+        trx ? (ids.length && (trx as any).clearCacheNsps.push([this.getCacheNsp(name, key), ids])) : (ids.length && deleteIds.push([this.getCacheNsp(name, key), ids]))
       })
     })
-    await this.redisCache.mDelete(deleteIds)
+    if (!trx) await this.redisCache.mDelete(deleteIds)
   }
 }

--- a/src/services/MysqlCache.ts
+++ b/src/services/MysqlCache.ts
@@ -155,6 +155,8 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
   async deleteCache(ids: string[], dataList: Array<CoaMysql.SafePartial<Scheme>>, trx?: CoaMysql.Transaction) {
     if (trx && !(trx as any).clearCacheNsps) {
       (trx as any).clearCacheNsps = [] as any
+    }
+    if (trx && (trx as any).clearCacheNsps) {
       (trx as any).clearCacheNsps.push([this.getCacheNsp('id'), ids]);
       (trx as any).clearCacheNsps.push([this.getCacheNsp('data'), []])
     }

--- a/src/services/MysqlCache.ts
+++ b/src/services/MysqlCache.ts
@@ -17,7 +17,7 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
   async insert(data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const id = await super.insert(data, trx)
     if (id) {
-      (trx && (trx as any).registerCacheClear) ? (trx as any).registerCacheClear(this, [id], [data]) : await this.deleteCache([id], [data])
+      (trx && (trx as any).trxUpdateCacheTaskList) ? (trx as any).trxUpdateCacheTaskList(this, [id], [data]) : await this.deleteCache([id], [data])
     }
     return id
   }
@@ -25,7 +25,7 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
   async mInsert(dataList: Array<CoaMysql.SafePartial<Scheme>>, trx?: CoaMysql.Transaction) {
     const ids = await super.mInsert(dataList, trx)
     if (ids) {
-      (trx && (trx as any).registerCacheClear) ? (trx as any).registerCacheClear(this, ids, dataList) : await this.deleteCache(ids, dataList)
+      (trx && (trx as any).trxUpdateCacheTaskList) ? (trx as any).trxUpdateCacheTaskList(this, ids, dataList) : await this.deleteCache(ids, dataList)
     }
     return ids
   }
@@ -34,7 +34,7 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
     const dataList = await this.getCacheChangedDataList([id], data, trx)
     const result = await super.updateById(id, data, trx)
     if (result) {
-      (trx && (trx as any).registerCacheClear) ? (trx as any).registerCacheClear(this, [id], dataList) : await this.deleteCache([id], dataList)
+      (trx && (trx as any).trxUpdateCacheTaskList) ? (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList)
     }
     return result
   }
@@ -43,7 +43,7 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
     const dataList = await this.getCacheChangedDataList(ids, data, trx)
     const result = await super.updateByIds(ids, data, trx)
     if (result) {
-      (trx && (trx as any).registerCacheClear) ? (trx as any).registerCacheClear(this, ids, dataList) : await this.deleteCache(ids, dataList)
+      (trx && (trx as any).trxUpdateCacheTaskList) ? (trx as any).trxUpdateCacheTaskList(this, ids, dataList) : await this.deleteCache(ids, dataList)
     }
     return result
   }
@@ -52,7 +52,7 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
     const dataList = await this.getCacheChangedDataList([id], data, trx)
     const result = await super.updateForQueryById(id, query, data, trx)
     if (result) {
-      (trx && (trx as any).registerCacheClear) ? (trx as any).registerCacheClear(this, [id], dataList) : await this.deleteCache([id], dataList)
+      (trx && (trx as any).trxUpdateCacheTaskList) ? (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList)
     }
     return result
   }
@@ -61,7 +61,7 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
     const dataList = await this.getCacheChangedDataList([id], data, trx)
     const result = await super.upsertById(id, data, trx)
     if (result) {
-      (trx && (trx as any).registerCacheClear) ? (trx as any).registerCacheClear(this, [id], dataList) : await this.deleteCache([id], dataList)
+      (trx && (trx as any).trxUpdateCacheTaskList) ? (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList)
     }
     return result
   }
@@ -70,7 +70,7 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
     const dataList = await this.getCacheChangedDataList(ids, undefined, trx)
     const result = await super.deleteByIds(ids, trx)
     if (result) {
-      (trx && (trx as any).registerCacheClear) ? (trx as any).registerCacheClear(this, ids, dataList) : await this.deleteCache(ids, dataList)
+      (trx && (trx as any).trxUpdateCacheTaskList) ? (trx as any).trxUpdateCacheTaskList(this, ids, dataList) : await this.deleteCache(ids, dataList)
     }
     return result
   }
@@ -81,17 +81,20 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
 
   async getById(id: string, pick = this.columns, trx?: CoaMysql.Transaction, ms = this.ms, force = false) {
     const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'id') : this.getCacheNsp('id')
+    trx && (trx as any).trxRaeadCacheNspsList(this, cacheNsp)
     const result = await this.redisCache.warp(cacheNsp, id, async () => await super.getById(id, this.columns, trx), ms, force)
     return this.pickResult(result, pick)
   }
 
   async getIdBy(field: string, value: string | number, trx?: CoaMysql.Transaction) {
     const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'index', field) : this.getCacheNsp('index', field)
+    trx && (trx as any).trxRaeadCacheNspsList(this, cacheNsp)
     return await this.redisCache.warp(cacheNsp, '' + value, async () => await super.getIdBy(field, value, trx))
   }
 
   async mGetByIds(ids: string[], pick = this.pick, trx?: CoaMysql.Transaction, ms = this.ms, force = false) {
     const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'id') : this.getCacheNsp('id')
+    trx && (trx as any).trxRaeadCacheNspsList(this, cacheNsp)
     const result = await this.redisCache.mWarp(cacheNsp, ids, async ids => await super.mGetByIds(ids, this.columns, trx), ms, force)
     _.forEach(result, (v, k) => {
       result[k] = this.pickResult(v, pick)
@@ -105,37 +108,37 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
   }
 
   protected async findListCount(finger: Array<CoaMysql.Dic<any>>, query: CoaMysql.Query, trx?: CoaMysql.Transaction) {
-    // const cacheNsp = this.getCacheNsp('data')
     const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'data') : this.getCacheNsp('data')
+    trx && (trx as any).trxRaeadCacheNspsList(this, cacheNsp)
     const cacheId = 'list-count:' + secure.sha1($.sortQueryString(...finger))
     return await this.redisCache.warp(cacheNsp, cacheId, async () => await super.selectListCount(query, trx))
   }
 
   protected async findIdList(finger: Array<CoaMysql.Dic<any>>, query: CoaMysql.Query, trx?: CoaMysql.Transaction) {
-    // const cacheNsp = this.getCacheNsp('data')
     const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'data') : this.getCacheNsp('data')
+    trx && (trx as any).trxRaeadCacheNspsList(this, cacheNsp)
     const cacheId = 'list:' + secure.sha1($.sortQueryString(...finger))
     return await this.redisCache.warp(cacheNsp, cacheId, async () => await super.selectIdList(query, trx))
   }
 
   protected async findIdSortList(finger: Array<CoaMysql.Dic<any>>, pager: CoaMysql.Pager, query: CoaMysql.Query, trx?: CoaMysql.Transaction) {
-    // const cacheNsp = this.getCacheNsp('data')
     const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'data') : this.getCacheNsp('data')
+    trx && (trx as any).trxRaeadCacheNspsList(this, cacheNsp)
     const cacheId = `sort-list:${pager.rows}:${pager.last}:` + secure.sha1($.sortQueryString(...finger))
     return await this.redisCache.warp(cacheNsp, cacheId, async () => await super.selectIdSortList(pager, query, trx))
   }
 
   protected async findIdViewList(finger: Array<CoaMysql.Dic<any>>, pager: CoaMysql.Pager, query: CoaMysql.Query, trx?: CoaMysql.Transaction) {
-    // const cacheNsp = this.getCacheNsp('data')
     const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'data') : this.getCacheNsp('data')
+    trx && (trx as any).trxRaeadCacheNspsList(this, cacheNsp)
     const cacheId = `view-list:${pager.rows}:${pager.page}:` + secure.sha1($.sortQueryString(...finger))
     const count = await this.findListCount(finger, query, trx)
     return await this.redisCache.warp(cacheNsp, cacheId, async () => await super.selectIdViewList(pager, query, trx, count))
   }
 
   protected async mGetCountBy(field: string, ids: string[], trx?: CoaMysql.Transaction) {
-    // const cacheNsp = this.getCacheNsp('count', field)
     const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'count', field) : this.getCacheNsp('count', field)
+    trx && (trx as any).trxRaeadCacheNspsList(this, cacheNsp)
     return await this.redisCache.mWarp(cacheNsp, ids, async ids => {
       const rows = (await this.table(trx).select({ id: field }).count({ count: this.key }).whereIn(field, ids).groupBy(field)) as any[]
       const result: CoaMysql.Dic<number> = {}
@@ -145,8 +148,8 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
   }
 
   protected async getCountBy(field: string, value: string, query?: CoaMysql.Query, trx?: CoaMysql.Transaction) {
-    // const cacheNsp = this.getCacheNsp('count', field)
     const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'count', field) : this.getCacheNsp('count', field)
+    trx && (trx as any).trxRaeadCacheNspsList(this, cacheNsp)
     return await this.redisCache.warp(cacheNsp, value, async () => {
       const qb = this.table(trx).count({ count: this.key })
       query ? query(qb) : qb.where(field, value)

--- a/src/services/MysqlCache.ts
+++ b/src/services/MysqlCache.ts
@@ -1,4 +1,3 @@
-import { echo } from 'coa-echo'
 import { CoaError } from 'coa-error'
 import { $, _ } from 'coa-helper'
 import { CoaRedis, RedisCache } from 'coa-redis'
@@ -171,7 +170,5 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
       })
     })
     await this.redisCache.mDelete(deleteIds)
-    echo.grey(`REDIS:DeleteIds${deleteIds};`)
-
   }
 }

--- a/src/services/MysqlCache.ts
+++ b/src/services/MysqlCache.ts
@@ -65,7 +65,7 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
   }
 
   async getById(id: string, pick = this.columns, trx?: CoaMysql.Transaction, ms = this.ms, force = false) {
-    const result = trx ? await super.getById(id, this.columns, trx) : await this.redisCache.warp(this.getCacheNsp('id'), id, async () => await super.getById(id, this.columns, trx), ms, force)
+    const result = trx?.__isSafeTransaction ? await super.getById(id, this.columns, trx) : await this.redisCache.warp(this.getCacheNsp('id'), id, async () => await super.getById(id, this.columns, trx), ms, force)
     return this.pickResult(result, pick)
   }
 

--- a/src/services/MysqlCache.ts
+++ b/src/services/MysqlCache.ts
@@ -154,7 +154,7 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
 
   async deleteCache(ids: string[], dataList: Array<CoaMysql.SafePartial<Scheme>>, trx?: CoaMysql.Transaction) {
     if (trx && !(trx as any).clearCacheNsps) {
-      (trx as any).clearCacheNsps = [] as any
+      (trx as any).clearCacheNsps = [] as CoaRedis.CacheDelete[]
     }
     if (trx && (trx as any).clearCacheNsps) {
       (trx as any).clearCacheNsps.push([this.getCacheNsp('id'), ids]);

--- a/src/services/MysqlCache.ts
+++ b/src/services/MysqlCache.ts
@@ -15,51 +15,49 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
   }
 
   async insert(data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
-    const id = await super.insert(data, trx)
+    const id = await super.insert(data, trx);
     trx && (trx as any).trxUpdateCacheTaskList ? await (trx as any).trxUpdateCacheTaskList(this, [id], [data]) : await this.deleteCache([id], [data])
     return id
   }
 
   async mInsert(dataList: Array<CoaMysql.SafePartial<Scheme>>, trx?: CoaMysql.Transaction) {
-    const ids = await super.mInsert(dataList, trx)
+    const ids = await super.mInsert(dataList, trx);
     trx && (trx as any).trxUpdateCacheTaskList ? await (trx as any).trxUpdateCacheTaskList(this, ids, dataList) : await this.deleteCache(ids, dataList)
     return ids
   }
 
   async updateById(id: string, data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList([id], data, trx)
-    const result = await super.updateById(id, data, trx)
+    const result = await super.updateById(id, data, trx);
     trx && (trx as any).trxUpdateCacheTaskList ? await (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList)
     return result
   }
 
   async updateByIds(ids: string[], data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList(ids, data, trx)
-    const result = await super.updateByIds(ids, data, trx)
+    const result = await super.updateByIds(ids, data, trx);
     trx && (trx as any).trxUpdateCacheTaskList ? await (trx as any).trxUpdateCacheTaskList(this, ids, dataList) : await this.deleteCache(ids, dataList)
     return result
   }
 
   async updateForQueryById(id: string, query: CoaMysql.Query, data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList([id], data, trx)
-    const result = await super.updateForQueryById(id, query, data, trx)
+    const result = await super.updateForQueryById(id, query, data, trx);
     trx && (trx as any).trxUpdateCacheTaskList ? await (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList)
     return result
   }
 
   async upsertById(id: string, data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList([id], data, trx)
-    const result = await super.upsertById(id, data, trx)
+    const result = await super.upsertById(id, data, trx);
     trx && (trx as any).trxUpdateCacheTaskList ? await (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList)
     return result
   }
 
   async deleteByIds(ids: string[], trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList(ids, undefined, trx)
-    const result = await super.deleteByIds(ids, trx)
-    if (result) {
-      (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, ids, dataList) : await this.deleteCache(ids, dataList)
-    }
+    const result = await super.deleteByIds(ids, trx);
+    trx && (trx as any).trxUpdateCacheTaskList ? await (trx as any).trxUpdateCacheTaskList(this, ids, dataList) : await this.deleteCache(ids, dataList)
     return result
   }
 
@@ -117,12 +115,8 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
       _.forEach(rows, ({ id, count }) => (result[id] = count))
       return result
     }
-
-    if (trx) {
-      return await queryFunction()
-    } else {
-      return await this.redisCache.mWarp(this.getCacheNsp('count', field), ids, queryFunction)
-    }
+    const result = trx ? await queryFunction() : await this.redisCache.mWarp(this.getCacheNsp('count', field), ids, queryFunction)
+    return result
   }
 
   protected async getCountBy(field: string, value: string, query?: CoaMysql.Query, trx?: CoaMysql.Transaction) {
@@ -132,14 +126,8 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
       const rows = await qb
       return (rows[0]?.count as number) || 0
     }
-
-    if (trx) {
-      // 事务内直接查询数据库，不走缓存
-      return await queryFunction()
-    } else {
-      // 非事务走缓存
-      return await this.redisCache.warp(this.getCacheNsp('count', field), value, queryFunction)
-    }
+    const result = trx ? await queryFunction() : await this.redisCache.warp(this.getCacheNsp('count', field), value, queryFunction)
+    return result
   }
 
   protected pickResult<T>(data: T, pick: string[]) {

--- a/src/services/MysqlCache.ts
+++ b/src/services/MysqlCache.ts
@@ -17,7 +17,7 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
   async insert(data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const id = await super.insert(data, trx)
     if (id) {
-      (trx && (trx as any).registerCacheClear) ? (trx as any).registerCacheClear(this, [id], data) : await this.deleteCache([id], [data])
+      (trx && (trx as any).registerCacheClear) ? (trx as any).registerCacheClear(this, [id], [data]) : await this.deleteCache([id], [data])
     }
     return id
   }

--- a/src/services/MysqlCache.ts
+++ b/src/services/MysqlCache.ts
@@ -68,19 +68,16 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
   }
 
   async getById(id: string, pick = this.columns, trx?: CoaMysql.Transaction, ms = this.ms, force = false) {
-    const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'id') : this.getCacheNsp('id')
-    const result = trx ? await super.getById(id, this.columns, trx) : await this.redisCache.warp(cacheNsp, id, async () => await super.getById(id, this.columns, trx), ms, force)
+    const result = trx ? await super.getById(id, this.columns, trx) : await this.redisCache.warp(this.getCacheNsp('id'), id, async () => await super.getById(id, this.columns, trx), ms, force)
     return this.pickResult(result, pick)
   }
 
   async getIdBy(field: string, value: string | number, trx?: CoaMysql.Transaction) {
-    const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'index', field) : this.getCacheNsp('index', field)
-    return trx ? await super.getIdBy(field, value, trx) : await this.redisCache.warp(cacheNsp, '' + value, async () => await super.getIdBy(field, value, trx))
+    return trx ? await super.getIdBy(field, value, trx) : await this.redisCache.warp(this.getCacheNsp('index', field), '' + value, async () => await super.getIdBy(field, value, trx))
   }
 
   async mGetByIds(ids: string[], pick = this.pick, trx?: CoaMysql.Transaction, ms = this.ms, force = false) {
-    const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'id') : this.getCacheNsp('id')
-    const result = trx ? await super.mGetByIds(ids, this.columns, trx) : await this.redisCache.mWarp(cacheNsp, ids, async ids => await super.mGetByIds(ids, this.columns, trx), ms, force)
+    const result = trx ? await super.mGetByIds(ids, this.columns, trx) : await this.redisCache.mWarp(this.getCacheNsp('id'), ids, async ids => await super.mGetByIds(ids, this.columns, trx), ms, force)
     _.forEach(result, (v, k) => {
       result[k] = this.pickResult(v, pick)
     })
@@ -93,28 +90,24 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
   }
 
   protected async findListCount(finger: Array<CoaMysql.Dic<any>>, query: CoaMysql.Query, trx?: CoaMysql.Transaction) {
-    const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'data') : this.getCacheNsp('data')
     const cacheId = 'list-count:' + secure.sha1($.sortQueryString(...finger))
-    return trx ? await super.selectListCount(query, trx) : await this.redisCache.warp(cacheNsp, cacheId, async () => await super.selectListCount(query, trx))
+    return trx ? await super.selectListCount(query, trx) : await this.redisCache.warp(this.getCacheNsp('data'), cacheId, async () => await super.selectListCount(query, trx))
   }
 
   protected async findIdList(finger: Array<CoaMysql.Dic<any>>, query: CoaMysql.Query, trx?: CoaMysql.Transaction) {
-    const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'data') : this.getCacheNsp('data')
     const cacheId = 'list:' + secure.sha1($.sortQueryString(...finger))
-    return trx ? await super.selectIdList(query, trx) : await this.redisCache.warp(cacheNsp, cacheId, async () => await super.selectIdList(query, trx))
+    return trx ? await super.selectIdList(query, trx) : await this.redisCache.warp(this.getCacheNsp('data'), cacheId, async () => await super.selectIdList(query, trx))
   }
 
   protected async findIdSortList(finger: Array<CoaMysql.Dic<any>>, pager: CoaMysql.Pager, query: CoaMysql.Query, trx?: CoaMysql.Transaction) {
-    const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'data') : this.getCacheNsp('data')
     const cacheId = `sort-list:${pager.rows}:${pager.last}:` + secure.sha1($.sortQueryString(...finger))
-    return trx ? await super.selectIdSortList(pager, query, trx) : await this.redisCache.warp(cacheNsp, cacheId, async () => await super.selectIdSortList(pager, query, trx))
+    return trx ? await super.selectIdSortList(pager, query, trx) : await this.redisCache.warp(this.getCacheNsp('data'), cacheId, async () => await super.selectIdSortList(pager, query, trx))
   }
 
   protected async findIdViewList(finger: Array<CoaMysql.Dic<any>>, pager: CoaMysql.Pager, query: CoaMysql.Query, trx?: CoaMysql.Transaction) {
-    const cacheNsp = trx ? this.getTransactionCacheNsp(trx, 'data') : this.getCacheNsp('data')
     const cacheId = `view-list:${pager.rows}:${pager.page}:` + secure.sha1($.sortQueryString(...finger))
     const count = await this.findListCount(finger, query, trx)
-    return trx ? await super.selectIdViewList(pager, query, trx, count) : await this.redisCache.warp(cacheNsp, cacheId, async () => await super.selectIdViewList(pager, query, trx, count))
+    return trx ? await super.selectIdViewList(pager, query, trx, count) : await this.redisCache.warp(this.getCacheNsp('data'), cacheId, async () => await super.selectIdViewList(pager, query, trx, count))
   }
 
   protected async mGetCountBy(field: string, ids: string[], trx?: CoaMysql.Transaction) {
@@ -128,8 +121,7 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
     if (trx) {
       return await queryFunction()
     } else {
-      const cacheNsp = this.getCacheNsp('count', field)
-      return await this.redisCache.mWarp(cacheNsp, ids, queryFunction)
+      return await this.redisCache.mWarp(this.getCacheNsp('count', field), ids, queryFunction)
     }
   }
 
@@ -146,8 +138,7 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
       return await queryFunction()
     } else {
       // 非事务走缓存
-      const cacheNsp = this.getCacheNsp('count', field)
-      return await this.redisCache.warp(cacheNsp, value, queryFunction)
+      return await this.redisCache.warp(this.getCacheNsp('count', field), value, queryFunction)
     }
   }
 
@@ -158,12 +149,6 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
 
   protected getCacheNsp(...nsp: string[]) {
     return this.system + ':' + this.name + ':' + nsp.join(':')
-  }
-
-  // 为每个事务维护独立的缓存空间
-  protected getTransactionCacheNsp(trx?: CoaMysql.Transaction, ...nsp: string[]) {
-    const base = this.system + ':' + this.name + ':' + nsp.join(':')
-    return trx && (trx as any).id ? `${base}:trx:${(trx as any).id}` : base
   }
 
   protected async getCacheChangedDataList(ids: string[], data?: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {

--- a/src/services/MysqlCache.ts
+++ b/src/services/MysqlCache.ts
@@ -15,48 +15,48 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
 
   async insert(data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const id = await super.insert(data, trx);
-    trx && (trx as any).trxUpdateCacheTaskList ? await (trx as any).trxUpdateCacheTaskList(this, [id], [data]) : await this.deleteCache([id], [data])
+    (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, [id], [data]) : await this.deleteCache([id], [data])
     return id
   }
 
   async mInsert(dataList: Array<CoaMysql.SafePartial<Scheme>>, trx?: CoaMysql.Transaction) {
     const ids = await super.mInsert(dataList, trx);
-    trx && (trx as any).trxUpdateCacheTaskList ? await (trx as any).trxUpdateCacheTaskList(this, ids, dataList) : await this.deleteCache(ids, dataList)
+    (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, ids, dataList) : await this.deleteCache(ids, dataList)
     return ids
   }
 
   async updateById(id: string, data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList([id], data, trx)
     const result = await super.updateById(id, data, trx);
-    trx && (trx as any).trxUpdateCacheTaskList ? await (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList)
+    (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList)
     return result
   }
 
   async updateByIds(ids: string[], data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList(ids, data, trx)
     const result = await super.updateByIds(ids, data, trx);
-    trx && (trx as any).trxUpdateCacheTaskList ? await (trx as any).trxUpdateCacheTaskList(this, ids, dataList) : await this.deleteCache(ids, dataList)
+    (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, ids, dataList) : await this.deleteCache(ids, dataList)
     return result
   }
 
   async updateForQueryById(id: string, query: CoaMysql.Query, data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList([id], data, trx)
     const result = await super.updateForQueryById(id, query, data, trx);
-    trx && (trx as any).trxUpdateCacheTaskList ? await (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList)
+    (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList)
     return result
   }
 
   async upsertById(id: string, data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList([id], data, trx)
     const result = await super.upsertById(id, data, trx);
-    trx && (trx as any).trxUpdateCacheTaskList ? await (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList)
+    (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList)
     return result
   }
 
   async deleteByIds(ids: string[], trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList(ids, undefined, trx)
     const result = await super.deleteByIds(ids, trx);
-    trx && (trx as any).trxUpdateCacheTaskList ? await (trx as any).trxUpdateCacheTaskList(this, ids, dataList) : await this.deleteCache(ids, dataList)
+    (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, ids, dataList) : await this.deleteCache(ids, dataList)
     return result
   }
 

--- a/src/services/MysqlCache.ts
+++ b/src/services/MysqlCache.ts
@@ -70,11 +70,11 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
   }
 
   async getIdBy(field: string, value: string | number, trx?: CoaMysql.Transaction) {
-    return (trx as any).__isSafeTransaction ? await super.getIdBy(field, value, trx) : await this.redisCache.warp(this.getCacheNsp('index', field), '' + value, async () => await super.getIdBy(field, value, trx))
+    return trx?.__isSafeTransaction ? await super.getIdBy(field, value, trx) : await this.redisCache.warp(this.getCacheNsp('index', field), '' + value, async () => await super.getIdBy(field, value, trx))
   }
 
   async mGetByIds(ids: string[], pick = this.pick, trx?: CoaMysql.Transaction, ms = this.ms, force = false) {
-    const result = (trx as any).__isSafeTransaction ? await super.mGetByIds(ids, this.columns, trx) : await this.redisCache.mWarp(this.getCacheNsp('id'), ids, async ids => await super.mGetByIds(ids, this.columns, trx), ms, force)
+    const result = trx?.__isSafeTransaction ? await super.mGetByIds(ids, this.columns, trx) : await this.redisCache.mWarp(this.getCacheNsp('id'), ids, async ids => await super.mGetByIds(ids, this.columns, trx), ms, force)
     _.forEach(result, (v, k) => {
       result[k] = this.pickResult(v, pick)
     })
@@ -88,23 +88,23 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
 
   protected async findListCount(finger: Array<CoaMysql.Dic<any>>, query: CoaMysql.Query, trx?: CoaMysql.Transaction) {
     const cacheId = 'list-count:' + secure.sha1($.sortQueryString(...finger))
-    return (trx as any)?.__isSafeTransaction ? await super.selectListCount(query, trx) : await this.redisCache.warp(this.getCacheNsp('data'), cacheId, async () => await super.selectListCount(query, trx))
+    return trx?.__isSafeTransaction ? await super.selectListCount(query, trx) : await this.redisCache.warp(this.getCacheNsp('data'), cacheId, async () => await super.selectListCount(query, trx))
   }
 
   protected async findIdList(finger: Array<CoaMysql.Dic<any>>, query: CoaMysql.Query, trx?: CoaMysql.Transaction) {
     const cacheId = 'list:' + secure.sha1($.sortQueryString(...finger))
-    return (trx as any)?.__isSafeTransaction ? await super.selectIdList(query, trx) : await this.redisCache.warp(this.getCacheNsp('data'), cacheId, async () => await super.selectIdList(query, trx))
+    return trx?.__isSafeTransaction ? await super.selectIdList(query, trx) : await this.redisCache.warp(this.getCacheNsp('data'), cacheId, async () => await super.selectIdList(query, trx))
   }
 
   protected async findIdSortList(finger: Array<CoaMysql.Dic<any>>, pager: CoaMysql.Pager, query: CoaMysql.Query, trx?: CoaMysql.Transaction) {
     const cacheId = `sort-list:${pager.rows}:${pager.last}:` + secure.sha1($.sortQueryString(...finger))
-    return (trx as any)?.__isSafeTransaction ? await super.selectIdSortList(pager, query, trx) : await this.redisCache.warp(this.getCacheNsp('data'), cacheId, async () => await super.selectIdSortList(pager, query, trx))
+    return trx?.__isSafeTransaction ? await super.selectIdSortList(pager, query, trx) : await this.redisCache.warp(this.getCacheNsp('data'), cacheId, async () => await super.selectIdSortList(pager, query, trx))
   }
 
   protected async findIdViewList(finger: Array<CoaMysql.Dic<any>>, pager: CoaMysql.Pager, query: CoaMysql.Query, trx?: CoaMysql.Transaction) {
     const cacheId = `view-list:${pager.rows}:${pager.page}:` + secure.sha1($.sortQueryString(...finger))
     const count = await this.findListCount(finger, query, trx)
-    return (trx as any)?.__isSafeTransaction ? await super.selectIdViewList(pager, query, trx, count) : await this.redisCache.warp(this.getCacheNsp('data'), cacheId, async () => await super.selectIdViewList(pager, query, trx, count))
+    return trx?.__isSafeTransaction ? await super.selectIdViewList(pager, query, trx, count) : await this.redisCache.warp(this.getCacheNsp('data'), cacheId, async () => await super.selectIdViewList(pager, query, trx, count))
   }
 
   protected async mGetCountBy(field: string, ids: string[], trx?: CoaMysql.Transaction) {
@@ -114,7 +114,7 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
       _.forEach(rows, ({ id, count }) => (result[id] = count))
       return result
     }
-    const result = (trx as any)?.__isSafeTransaction ? await queryFunction() : await this.redisCache.mWarp(this.getCacheNsp('count', field), ids, queryFunction)
+    const result = trx?.__isSafeTransaction ? await queryFunction() : await this.redisCache.mWarp(this.getCacheNsp('count', field), ids, queryFunction)
     return result
   }
 
@@ -125,7 +125,7 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
       const rows = await qb
       return (rows[0]?.count as number) || 0
     }
-    const result = (trx as any)?.__isSafeTransaction ? await queryFunction() : await this.redisCache.warp(this.getCacheNsp('count', field), value, queryFunction)
+    const result = trx?.__isSafeTransaction ? await queryFunction() : await this.redisCache.warp(this.getCacheNsp('count', field), value, queryFunction)
     return result
   }
 
@@ -154,7 +154,7 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
 
   async deleteCache(ids: string[], dataList: Array<CoaMysql.SafePartial<Scheme>>, trx?: CoaMysql.Transaction) {
     const deleteIds = [] as CoaRedis.CacheDelete[]
-    if ((trx as any)?.__isSafeTransaction) {
+    if (trx?.__isSafeTransaction) {
       (trx as any)?.clearCacheNsps.push([this.getCacheNsp('id'), ids]);
       (trx as any)?.clearCacheNsps.push([this.getCacheNsp('data'), []])
     } else {
@@ -172,10 +172,10 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
         })
         ids.push(...keys.slice(1))
         if (ids.length) {
-          ((trx as any)?.__isSafeTransaction) ? (trx as any)?.clearCacheNsps.push([this.getCacheNsp(name, key), ids]) : deleteIds.push([this.getCacheNsp(name, key), ids])
+          (trx?.__isSafeTransaction) ? (trx as any)?.clearCacheNsps.push([this.getCacheNsp(name, key), ids]) : deleteIds.push([this.getCacheNsp(name, key), ids])
         }
       })
     })
-    if (!(trx as any)?.__isSafeTransaction) await this.redisCache.mDelete(deleteIds)
+    if (!trx?.__isSafeTransaction) await this.redisCache.mDelete(deleteIds)
   }
 }

--- a/src/services/MysqlCache.ts
+++ b/src/services/MysqlCache.ts
@@ -153,13 +153,14 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
   }
 
   async deleteCache(ids: string[], dataList: Array<CoaMysql.SafePartial<Scheme>>, trx?: CoaMysql.Transaction) {
+    const deleteIds = [] as CoaRedis.CacheDelete[]
     if ((trx as any)?.__isSafeTransaction) {
       (trx as any)?.clearCacheNsps.push([this.getCacheNsp('id'), ids]);
       (trx as any)?.clearCacheNsps.push([this.getCacheNsp('data'), []])
+    } else {
+      deleteIds.push([this.getCacheNsp('id'), ids])
+      deleteIds.push([this.getCacheNsp('data'), []])
     }
-    const deleteIds = [] as CoaRedis.CacheDelete[]
-    deleteIds.push([this.getCacheNsp('id'), ids])
-    deleteIds.push([this.getCacheNsp('data'), []])
     _.forEach(this.caches, (items, name) => {
       // name可能为index,count,或自定义
       items.forEach(item => {

--- a/src/services/MysqlCache.ts
+++ b/src/services/MysqlCache.ts
@@ -28,35 +28,35 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
   async updateById(id: string, data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList([id], data, trx)
     const result = await super.updateById(id, data, trx);
-    (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList)
+    if (result) { (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList) }
     return result
   }
 
   async updateByIds(ids: string[], data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList(ids, data, trx)
     const result = await super.updateByIds(ids, data, trx);
-    (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, ids, dataList) : await this.deleteCache(ids, dataList)
+    if (result) { (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, ids, dataList) : await this.deleteCache(ids, dataList) }
     return result
   }
 
   async updateForQueryById(id: string, query: CoaMysql.Query, data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList([id], data, trx)
     const result = await super.updateForQueryById(id, query, data, trx);
-    (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList)
+    if (result) { (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList) }
     return result
   }
 
   async upsertById(id: string, data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList([id], data, trx)
     const result = await super.upsertById(id, data, trx);
-    (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList)
+    if (result) { (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList) }
     return result
   }
 
   async deleteByIds(ids: string[], trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList(ids, undefined, trx)
     const result = await super.deleteByIds(ids, trx);
-    (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, ids, dataList) : await this.deleteCache(ids, dataList)
+    if (result) { (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, ids, dataList) : await this.deleteCache(ids, dataList) }
     return result
   }
 

--- a/src/services/MysqlCache.ts
+++ b/src/services/MysqlCache.ts
@@ -49,7 +49,7 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
   async upsertById(id: string, data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList([id], data, trx)
     const result = await super.upsertById(id, data, trx);
-    if (result) { (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList) }
+    (trx && (trx as any).trxUpdateCacheTaskList) ? await (trx as any).trxUpdateCacheTaskList(this, [id], dataList) : await this.deleteCache([id], dataList)
     return result
   }
 

--- a/src/services/MysqlCache.ts
+++ b/src/services/MysqlCache.ts
@@ -28,21 +28,21 @@ export class MysqlCache<Scheme> extends MysqlNative<Scheme> {
   async updateById(id: string, data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList([id], data, trx)
     const result = await super.updateById(id, data, trx)
-    await this.deleteCache([id], dataList, trx)
+    if (result) await this.deleteCache([id], dataList, trx)
     return result
   }
 
   async updateByIds(ids: string[], data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList(ids, data, trx)
     const result = await super.updateByIds(ids, data, trx);
-    await this.deleteCache(ids, dataList, trx)
+    if (result) await this.deleteCache(ids, dataList, trx)
     return result
   }
 
   async updateForQueryById(id: string, query: CoaMysql.Query, data: CoaMysql.SafePartial<Scheme>, trx?: CoaMysql.Transaction) {
     const dataList = await this.getCacheChangedDataList([id], data, trx)
     const result = await super.updateForQueryById(id, query, data, trx);
-    await this.deleteCache([id], dataList, trx)
+    if (result) await this.deleteCache([id], dataList, trx)
     return result
   }
 

--- a/src/test/demo.ts
+++ b/src/test/demo.ts
@@ -1,67 +1,68 @@
 /* eslint-disable @typescript-eslint/no-redeclare */
 // @ts-nocheck
-import { $, _ } from 'coa-helper'
-import { RedisBin, RedisCache } from 'coa-redis'
-import { MysqlBin, MysqlCache } from '..'
+import { CoaMysql, MysqlBin, MysqlNative } from '..'
+
 // MySQL配置
 const mysqlConfig = {
   host: '127.0.0.1',
   port: 3306,
   user: 'root',
-  password: '19990728',
+  password: 'root',
   charset: 'utf8mb4',
   trace: true,
   debug: false,
   databases: {
-    main: { database: 'mm-site-t1', ms: 7 * 24 * 3600 * 1000 },
+    main: { database: 'test', ms: 7 * 24 * 3600 * 1000 },
+    other: { database: 'other', ms: 7 * 24 * 3600 * 1000 },
   },
 }
-
-const redisConfig = {
-  host: '127.0.0.1',
-  port: 6379,
-  password: '',
-  db: 1,
-  prefix: '',
-  trace: false,
-
-}
-const redisBin = new RedisBin(redisConfig)
-const redisCache = new RedisCache(redisBin)
 
 // 初始化Mysql基本连接，后续所有模型均依赖此实例
 const mysqlBin = new MysqlBin(mysqlConfig)
 
+// 基本SQL操作
+
+// 插入数据 https://knexjs.org/#Builder-insert
+await mysqlBin.io.table('user').insert({ userId: 'user-a', name: 'A', mobile: '15010001001', gender: 1, language: 'zh-CN', status: 1 })
+
+// 查询全部数据，详见 https://knexjs.org/#Builder-select
+await mysqlBin.io.table('user').select()
+await mysqlBin.io.select('*').from('user')
+
+// 带条件查询，详见 https://knexjs.org/#Builder-where
+await mysqlBin.io.table('user').where('status', '=', 1)
+
+// 修改数据，详见 http://knexjs.org/#Builder-update
+await mysqlBin.io.table('user').update({ name: 'AA', gender: 2 }).where({ userId: 'user-a' })
+
+// 删除数据，详见 http://knexjs.org/#Builder-del%20/%20delete
+await mysqlBin.io.table('user').delete().where({ userId: 'user-a' })
+
+// 通过mysqlBin定义一个模型的基类，各个模型都可以使用这个基类
+export class MysqlNativeModel<T> extends MysqlNative<T> {
+  constructor(option: CoaMysql.ModelOption<T>) {
+    // 将实例配置bin绑定
+    super(option, mysqlBin)
+  }
+
+  // 也可以定义一些通用方法
+  commonMethod() {
+    // do something
+  }
+}
+
+// 定义User默认结构
 const userScheme = {
   userId: '' as string,
   name: '' as string,
-  mobile: '' as string,
-  avatar: '' as string,
-  gender: 1 as number,
-  language: '' as string,
-  status: 1 as number,
   created: 0 as number,
   updated: 0 as number,
 }
-
-// const userScheme1 = {
-//   userId: '' as string,
-//   name: '' as string,
-//   mobile: '' as string,
-//   avatar: '' as string,
-//   gender: 1 as number,
-//   language: '' as string,
-//   status: 1 as number,
-//   created: 0 as number,
-//   updated: 0 as number,
-// }
-
 // 定义User类型（通过默认结构自动生成）
 type UserScheme = typeof userScheme
 
-
 // 通过基类初始化
-const User = new (class extends MysqlCache<UserScheme> {
+const User = new (class extends MysqlNative<UserScheme> {
   constructor() {
     super(
       {
@@ -69,52 +70,73 @@ const User = new (class extends MysqlCache<UserScheme> {
         title: '用户表', // 表的备注名称
         scheme: userScheme, // 表的默认结构
         pick: ['userId', 'name'], // 查询列表时显示的字段信息
-        caches: { index: ['name'], count: ['userId', 'name'] },
-
       },
-      mysqlBin,
-      redisCache,
-    )
+      mysqlBin
+    ) // 绑定配置实例bin
+  }
+
+  // 自定义方法
+  async customMethod() {
+    // 做一些事情
   }
 })()
 
-// const User1 = new (class extends MysqlCache<UserScheme> {
-//   constructor() {
-//     super(
-//       {
-//         name: 'User1', // 表名，默认会转化为下划线(snackCase)形式，如 User->user UserPhoto->user_photo
-//         title: '用户表', // 表的备注名称
-//         scheme: userScheme1, // 表的默认结构
-//         pick: ['userId', 'name'], // 查询列表时显示的字段信息
-//       },
-//       mysqlBin,
-//       redisCache,
-//     )
-//   }
-// })()
+// 通过基类模型定义用户模型
+const User = new (class extends MysqlNativeModel<UserScheme> {
+  constructor() {
+    super({ name: 'User', title: '用户表', scheme: userScheme, pick: ['userId', 'name'] })
+  }
+
+  // 自定义方法
+  async customMethodForUser() {
+    // 做一些事情
+  }
+})()
+
+// 通过基类模型定义管理员模型
+const Manager = new (class extends MysqlNativeModel<UserScheme> {
+  constructor() {
+    super({ name: 'Manager', title: '管理员表', scheme: userScheme, pick: ['userId', 'name'] })
+  }
+})()
+
+// 用户模型和管理员模型均可以调用公共方法
+await User.commonMethod()
+await Manager.commonMethod()
+
+// 仅仅用户模型可以调用自定义方法
+await User.customMethodForUser()
+
+// 插入
+await User.insert({ name: '王小明', gender: 1 }) // 返回 'id001'，即该条数据的 userId = 'id001'
 
 // 批量插入
-// await User.mInsert([
-//   { name: '王小明', gender: 1 },
-//   { name: '宋小华', gender: 1 },
-// ])
+await User.mInsert([
+  { name: '王小明', gender: 1 },
+  { name: '宋小华', gender: 1 },
+]) // 返回 ['id002','id003']
 
-// await User.updateById('id002', { name: '李四' }) // 返回 1
-const a = async () => {
-  await User.checkById('41102319990728253X')
-  await mysqlBin.safeTransaction(async (trx: CoaMysql.Transaction) => {
-    await User.updateById('41102319990728253X', { name: 'mmm' }, trx)
-    for (let index = 0; index < 10; index++) {
-      const userId = `${_.now()}-${index}-Y`
-      await $.timeout(3000)
-      await User.insert({ userId, name: 'heyifan2' }, trx)
-    }
-  })
-  const b = await User.checkById('41102319990728253X')
-  console.log(b);
-  // const id = await redisCache.clearUseless('*id')
-  // console.log('cRedis: ID类型过期缓存清除成功', id)
-  // const data = await redisCache.clearUseless('*data')
-  // console.log('cRedis: DATA类型过期缓存清除成功', data)
-}
-a()
+// 通过ID更新
+await User.updateById('id002', { name: '李四' }) // 返回 1
+
+// 通过ID批量更新
+await User.updateByIds(['id002', 'id003'], { status: 2 }) // 返回 2
+
+// 通过ID更新或插入(如果id存在就更新，如果不存在就插入)
+await User.upsertById('id002', { name: '王小明', gender: 1 }) // 返回 1 ，更新了一条 userId = 'id02' 的数据
+await User.upsertById('id004', { name: '李四', gender: 1 }) // 返回 0 ，插入一条新数据，数据的 userId = 'id04'
+
+// 通过ID删除多个
+await User.deleteByIds(['id003', 'id004']) // 返回 2
+
+// 通过ID查询一个，第二个参数设置返回结果所包含的数据
+await User.getById('id001', ['name']) // 数据为{userId:'id001',name:'王小明',gender:1,status:1,...} 实际返回 {userId:'id001',name:'王小明'}
+
+// 通过ID获取多个
+await User.mGetByIds(['id001', 'id002'], ['name']) // 返回 {id001:{userId:'id001',name:'王小明'},id002:{userId:'id002',name:'李四'}}
+
+// 截断表
+await User.truncate() // 无返回值，主要不报错即成功截断整个表
+
+// 自定义方法
+await User.customMethod() // 执行自定义方法

--- a/src/test/demo.ts
+++ b/src/test/demo.ts
@@ -1,57 +1,37 @@
 /* eslint-disable @typescript-eslint/no-redeclare */
 // @ts-nocheck
-import { CoaMysql, MysqlBin, MysqlNative } from '..'
-
+import { $, _ } from 'coa-helper'
+import { RedisBin, RedisCache } from 'coa-redis'
+import { MysqlBin, MysqlCache } from '..'
 // MySQL配置
 const mysqlConfig = {
   host: '127.0.0.1',
   port: 3306,
   user: 'root',
-  password: 'root',
+  password: '19990728',
   charset: 'utf8mb4',
   trace: true,
   debug: false,
   databases: {
-    main: { database: 'test', ms: 7 * 24 * 3600 * 1000 },
-    other: { database: 'other', ms: 7 * 24 * 3600 * 1000 },
+    main: { database: 'mm-site-t1', ms: 7 * 24 * 3600 * 1000 },
   },
 }
+
+const redisConfig = {
+  host: '127.0.0.1',
+  port: 6379,
+  password: '',
+  db: 1,
+  prefix: '',
+  trace: false,
+
+}
+const redisBin = new RedisBin(redisConfig)
+const redisCache = new RedisCache(redisBin)
 
 // 初始化Mysql基本连接，后续所有模型均依赖此实例
 const mysqlBin = new MysqlBin(mysqlConfig)
 
-// 基本SQL操作
-
-// 插入数据 https://knexjs.org/#Builder-insert
-await mysqlBin.io.table('user').insert({ userId: 'user-a', name: 'A', mobile: '15010001001', gender: 1, language: 'zh-CN', status: 1 })
-
-// 查询全部数据，详见 https://knexjs.org/#Builder-select
-await mysqlBin.io.table('user').select()
-await mysqlBin.io.select('*').from('user')
-
-// 带条件查询，详见 https://knexjs.org/#Builder-where
-await mysqlBin.io.table('user').where('status', '=', 1)
-
-// 修改数据，详见 http://knexjs.org/#Builder-update
-await mysqlBin.io.table('user').update({ name: 'AA', gender: 2 }).where({ userId: 'user-a' })
-
-// 删除数据，详见 http://knexjs.org/#Builder-del%20/%20delete
-await mysqlBin.io.table('user').delete().where({ userId: 'user-a' })
-
-// 通过mysqlBin定义一个模型的基类，各个模型都可以使用这个基类
-export class MysqlNativeModel<T> extends MysqlNative<T> {
-  constructor(option: CoaMysql.ModelOption<T>) {
-    // 将实例配置bin绑定
-    super(option, mysqlBin)
-  }
-
-  // 也可以定义一些通用方法
-  commonMethod() {
-    // do something
-  }
-}
-
-// 定义User默认结构
 const userScheme = {
   userId: '' as string,
   name: '' as string,
@@ -63,11 +43,25 @@ const userScheme = {
   created: 0 as number,
   updated: 0 as number,
 }
+
+// const userScheme1 = {
+//   userId: '' as string,
+//   name: '' as string,
+//   mobile: '' as string,
+//   avatar: '' as string,
+//   gender: 1 as number,
+//   language: '' as string,
+//   status: 1 as number,
+//   created: 0 as number,
+//   updated: 0 as number,
+// }
+
 // 定义User类型（通过默认结构自动生成）
 type UserScheme = typeof userScheme
 
+
 // 通过基类初始化
-const User = new (class extends MysqlNative<UserScheme> {
+const User = new (class extends MysqlCache<UserScheme> {
   constructor() {
     super(
       {
@@ -76,72 +70,44 @@ const User = new (class extends MysqlNative<UserScheme> {
         scheme: userScheme, // 表的默认结构
         pick: ['userId', 'name'], // 查询列表时显示的字段信息
       },
-      mysqlBin
-    ) // 绑定配置实例bin
-  }
-
-  // 自定义方法
-  async customMethod() {
-    // 做一些事情
+      mysqlBin,
+      redisCache,
+    )
   }
 })()
 
-// 通过基类模型定义用户模型
-const User = new (class extends MysqlNativeModel<UserScheme> {
-  constructor() {
-    super({ name: 'User', title: '用户表', scheme: userScheme, pick: ['userId', 'name'] })
-  }
-
-  // 自定义方法
-  async customMethodForUser() {
-    // 做一些事情
-  }
-})()
-
-// 通过基类模型定义管理员模型
-const Manager = new (class extends MysqlNativeModel<UserScheme> {
-  constructor() {
-    super({ name: 'Manager', title: '管理员表', scheme: userScheme, pick: ['userId', 'name'] })
-  }
-})()
-
-// 用户模型和管理员模型均可以调用公共方法
-await User.commonMethod()
-await Manager.commonMethod()
-
-// 仅仅用户模型可以调用自定义方法
-await User.customMethodForUser()
-
-// 插入
-await User.insert({ name: '王小明', gender: 1 }) // 返回 'id001'，即该条数据的 userId = 'id001'
+// const User1 = new (class extends MysqlCache<UserScheme> {
+//   constructor() {
+//     super(
+//       {
+//         name: 'User1', // 表名，默认会转化为下划线(snackCase)形式，如 User->user UserPhoto->user_photo
+//         title: '用户表', // 表的备注名称
+//         scheme: userScheme1, // 表的默认结构
+//         pick: ['userId', 'name'], // 查询列表时显示的字段信息
+//       },
+//       mysqlBin,
+//       redisCache,
+//     )
+//   }
+// })()
 
 // 批量插入
-await User.mInsert([
-  { name: '王小明', gender: 1 },
-  { name: '宋小华', gender: 1 },
-]) // 返回 ['id002','id003']
+// await User.mInsert([
+//   { name: '王小明', gender: 1 },
+//   { name: '宋小华', gender: 1 },
+// ])
 
-// 通过ID更新
-await User.updateById('id002', { name: '李四' }) // 返回 1
+// await User.updateById('id002', { name: '李四' }) // 返回 1
+const a = async () => {
+  await mysqlBin.safeTransaction(async (trx: CoaMysql.Transaction) => {
+    await User.updateById('41102319990728253X', { name: 'mmm' }, trx)
+    const q = await User.checkById('41102319990728253X', ['name'], trx)
+    console.log(q);
+    await $.timeout(3000)
+    await User.insert({ name: 'heyifan2', userId: `${_.now()}Y${123}` }, trx)
+  })
+  const b = await User.checkById('41102319990728253X')
+  console.log(b);
 
-// 通过ID批量更新
-await User.updateByIds(['id002', 'id003'], { status: 2 }) // 返回 2
-
-// 通过ID更新或插入(如果id存在就更新，如果不存在就插入)
-await User.upsertById('id002', { name: '王小明', gender: 1 }) // 返回 1 ，更新了一条 userId = 'id02' 的数据
-await User.upsertById('id004', { name: '李四', gender: 1 }) // 返回 0 ，插入一条新数据，数据的 userId = 'id04'
-
-// 通过ID删除多个
-await User.deleteByIds(['id003', 'id004']) // 返回 2
-
-// 通过ID查询一个，第二个参数设置返回结果所包含的数据
-await User.getById('id001', ['name']) // 数据为{userId:'id001',name:'王小明',gender:1,status:1,...} 实际返回 {userId:'id001',name:'王小明'}
-
-// 通过ID获取多个
-await User.mGetByIds(['id001', 'id002'], ['name']) // 返回 {id001:{userId:'id001',name:'王小明'},id002:{userId:'id002',name:'李四'}}
-
-// 截断表
-await User.truncate() // 无返回值，主要不报错即成功截断整个表
-
-// 自定义方法
-await User.customMethod() // 执行自定义方法
+}
+a()

--- a/src/test/demo.ts
+++ b/src/test/demo.ts
@@ -55,6 +55,11 @@ export class MysqlNativeModel<T> extends MysqlNative<T> {
 const userScheme = {
   userId: '' as string,
   name: '' as string,
+  mobile: '' as string,
+  avatar: '' as string,
+  gender: 1 as number,
+  language: '' as string,
+  status: 1 as number,
   created: 0 as number,
   updated: 0 as number,
 }

--- a/src/test/demo.ts
+++ b/src/test/demo.ts
@@ -69,7 +69,8 @@ const User = new (class extends MysqlCache<UserScheme> {
         title: '用户表', // 表的备注名称
         scheme: userScheme, // 表的默认结构
         pick: ['userId', 'name'], // 查询列表时显示的字段信息
-        caches: { index: ['name'], count: ['userId', 'name'] }
+        caches: { index: ['name'], count: ['userId', 'name'] },
+
       },
       mysqlBin,
       redisCache,

--- a/src/test/demo.ts
+++ b/src/test/demo.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-redeclare */
 // @ts-nocheck
-import { $ } from 'coa-helper'
+import { $, _ } from 'coa-helper'
 import { RedisBin, RedisCache } from 'coa-redis'
 import { MysqlBin, MysqlCache } from '..'
 // MySQL配置
@@ -69,6 +69,7 @@ const User = new (class extends MysqlCache<UserScheme> {
         title: '用户表', // 表的备注名称
         scheme: userScheme, // 表的默认结构
         pick: ['userId', 'name'], // 查询列表时显示的字段信息
+        caches: { index: ['name'], count: ['userId', 'name'] }
       },
       mysqlBin,
       redisCache,
@@ -99,12 +100,14 @@ const User = new (class extends MysqlCache<UserScheme> {
 
 // await User.updateById('id002', { name: '李四' }) // 返回 1
 const a = async () => {
+  await User.checkById('41102319990728253X')
   await mysqlBin.safeTransaction(async (trx: CoaMysql.Transaction) => {
     await User.updateById('41102319990728253X', { name: 'mmm' }, trx)
-    const q = await User.checkById('41102319990728253X', Object.keys(userScheme), trx)
-    console.log(q);
-    await $.timeout(3000)
-    await User.updateById('1758003943672Y2', { name: 'heyifan2' }, trx)
+    for (let index = 0; index < 10; index++) {
+      const userId = `${_.now()}-${index}-Y`
+      await $.timeout(3000)
+      await User.insert({ userId, name: 'heyifan2' }, trx)
+    }
   })
   const b = await User.checkById('41102319990728253X')
   console.log(b);

--- a/src/test/demo.ts
+++ b/src/test/demo.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-redeclare */
 // @ts-nocheck
-import { $, _ } from 'coa-helper'
+import { $ } from 'coa-helper'
 import { RedisBin, RedisCache } from 'coa-redis'
 import { MysqlBin, MysqlCache } from '..'
 // MySQL配置
@@ -101,13 +101,16 @@ const User = new (class extends MysqlCache<UserScheme> {
 const a = async () => {
   await mysqlBin.safeTransaction(async (trx: CoaMysql.Transaction) => {
     await User.updateById('41102319990728253X', { name: 'mmm' }, trx)
-    const q = await User.checkById('41102319990728253X', ['name'], trx)
+    const q = await User.checkById('41102319990728253X', Object.keys(userScheme), trx)
     console.log(q);
     await $.timeout(3000)
-    await User.insert({ name: 'heyifan2', userId: `${_.now()}Y${123}` }, trx)
+    await User.updateById('1758003943672Y2', { name: 'heyifan2' }, trx)
   })
   const b = await User.checkById('41102319990728253X')
   console.log(b);
-
+  // const id = await redisCache.clearUseless('*id')
+  // console.log('cRedis: ID类型过期缓存清除成功', id)
+  // const data = await redisCache.clearUseless('*data')
+  // console.log('cRedis: DATA类型过期缓存清除成功', data)
 }
 a()

--- a/src/test/demoSafeTransaction.ts
+++ b/src/test/demoSafeTransaction.ts
@@ -45,17 +45,6 @@ const userScheme = {
     updated: 0 as number,
 }
 
-// const userScheme1 = {
-//   userId: '' as string,
-//   name: '' as string,
-//   mobile: '' as string,
-//   avatar: '' as string,
-//   gender: 1 as number,
-//   language: '' as string,
-//   status: 1 as number,
-//   created: 0 as number,
-//   updated: 0 as number,
-// }
 
 // 定义User类型（通过默认结构自动生成）
 type UserScheme = typeof userScheme
@@ -79,28 +68,6 @@ const User = new (class extends MysqlCache<UserScheme> {
     }
 })()
 
-// const User1 = new (class extends MysqlCache<UserScheme> {
-//   constructor() {
-//     super(
-//       {
-//         name: 'User1', // 表名，默认会转化为下划线(snackCase)形式，如 User->user UserPhoto->user_photo
-//         title: '用户表', // 表的备注名称
-//         scheme: userScheme1, // 表的默认结构
-//         pick: ['userId', 'name'], // 查询列表时显示的字段信息
-//       },
-//       mysqlBin,
-//       redisCache,
-//     )
-//   }
-// })()
-
-// 批量插入
-// await User.mInsert([
-//   { name: '王小明', gender: 1 },
-//   { name: '宋小华', gender: 1 },
-// ])
-
-// await User.updateById('id002', { name: '李四' }) // 返回 1
 const a = async () => {
     await User.checkById('41102319990728253X')
     await $.timeout(3000)

--- a/src/test/demoSafeTransaction.ts
+++ b/src/test/demoSafeTransaction.ts
@@ -1,0 +1,118 @@
+/* eslint-disable @typescript-eslint/no-redeclare */
+// @ts-nocheck
+import { $, _ } from 'coa-helper'
+import { RedisBin, RedisCache } from 'coa-redis'
+import { MysqlBin, MysqlCache, MysqlSafeTransaction } from '..'
+// MySQL配置
+const mysqlConfig = {
+    host: '127.0.0.1',
+    port: 3306,
+    user: 'root',
+    password: '',
+    charset: 'utf8mb4',
+    trace: true,
+    debug: false,
+    databases: {
+        main: { database: 'coa-mysql', ms: 7 * 24 * 3600 * 1000 },
+    },
+}
+
+const redisConfig = {
+    host: '127.0.0.1',
+    port: 6379,
+    password: '',
+    db: 1,
+    prefix: 'coa-mysql',
+    trace: false,
+
+}
+const redisBin = new RedisBin(redisConfig)
+const redisCache = new RedisCache(redisBin)
+
+// 初始化Mysql基本连接，后续所有模型均依赖此实例
+const mysqlBin = new MysqlBin(mysqlConfig)
+const safeTransaction = new MysqlSafeTransaction(mysqlBin)
+
+const userScheme = {
+    userId: '' as string,
+    name: '' as string,
+    mobile: '' as string,
+    avatar: '' as string,
+    gender: 1 as number,
+    language: '' as string,
+    status: 1 as number,
+    created: 0 as number,
+    updated: 0 as number,
+}
+
+// const userScheme1 = {
+//   userId: '' as string,
+//   name: '' as string,
+//   mobile: '' as string,
+//   avatar: '' as string,
+//   gender: 1 as number,
+//   language: '' as string,
+//   status: 1 as number,
+//   created: 0 as number,
+//   updated: 0 as number,
+// }
+
+// 定义User类型（通过默认结构自动生成）
+type UserScheme = typeof userScheme
+
+
+// 通过基类初始化
+const User = new (class extends MysqlCache<UserScheme> {
+    constructor() {
+        super(
+            {
+                name: 'User', // 表名，默认会转化为下划线(snackCase)形式，如 User->user UserPhoto->user_photo
+                title: '用户表', // 表的备注名称
+                scheme: userScheme, // 表的默认结构
+                pick: ['userId', 'name'], // 查询列表时显示的字段信息
+                caches: { index: ['name'], count: ['userId', 'name'] },
+
+            },
+            mysqlBin,
+            redisCache,
+        )
+    }
+})()
+
+// const User1 = new (class extends MysqlCache<UserScheme> {
+//   constructor() {
+//     super(
+//       {
+//         name: 'User1', // 表名，默认会转化为下划线(snackCase)形式，如 User->user UserPhoto->user_photo
+//         title: '用户表', // 表的备注名称
+//         scheme: userScheme1, // 表的默认结构
+//         pick: ['userId', 'name'], // 查询列表时显示的字段信息
+//       },
+//       mysqlBin,
+//       redisCache,
+//     )
+//   }
+// })()
+
+// 批量插入
+// await User.mInsert([
+//   { name: '王小明', gender: 1 },
+//   { name: '宋小华', gender: 1 },
+// ])
+
+// await User.updateById('id002', { name: '李四' }) // 返回 1
+const a = async () => {
+    await User.checkById('41102319990728253X')
+    await $.timeout(3000)
+    await safeTransaction.safeTransaction(async (trx: CoaMysql.Transaction) => {
+        await User.updateById('41102319990728253X', { name: 'mmm' })
+        for (let index = 0; index < 10; index++) {
+            const userId = `${_.now()}-${index}-Y`
+            await User.insert({ userId, name: 'heyifan2' }, trx)
+        }
+    })
+    await $.timeout(3000)
+    const b = await User.checkById('41102319990728253X')
+    console.log(b);
+}
+a()

--- a/src/test/demoSafeTransaction.ts
+++ b/src/test/demoSafeTransaction.ts
@@ -69,17 +69,17 @@ const User = new (class extends MysqlCache<UserScheme> {
 })()
 
 const a = async () => {
-    await User.checkById('41102319990728253X')
+    await User.checkById('411******728253X')
     await $.timeout(3000)
     await safeTransaction.safeTransaction(async (trx: CoaMysql.Transaction) => {
-        await User.updateById('41102319990728253X', { name: 'mmm' })
+        await User.updateById('411******728253X', { name: 'mmm' })
         for (let index = 0; index < 10; index++) {
             const userId = `${_.now()}-${index}-Y`
             await User.insert({ userId, name: 'heyifan2' }, trx)
         }
     })
     await $.timeout(3000)
-    const b = await User.checkById('41102319990728253X')
+    const b = await User.checkById('411******728253X')
     console.log(b);
 }
 a()

--- a/src/test/demoSafeTransaction.ts
+++ b/src/test/demoSafeTransaction.ts
@@ -31,7 +31,7 @@ const redisCache = new RedisCache(redisBin)
 
 // 初始化Mysql基本连接，后续所有模型均依赖此实例
 const mysqlBin = new MysqlBin(mysqlConfig)
-const safeTransaction = new MysqlSafeTransaction(mysqlBin)
+const safeTransaction = new MysqlSafeTransaction(mysqlBin, redisCache)
 
 const userScheme = {
     userId: '' as string,

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -7,7 +7,10 @@ export namespace CoaMysql {
   export type SafePartial<T> = T extends {} ? Partial<T> : any
   export type Query = (qb: Knex.QueryBuilder) => void
   export type QueryBuilder = Knex.QueryBuilder
-  export type Transaction = Knex.Transaction
+  export interface Transaction extends Knex.Transaction {
+    __isSafeTransaction?: boolean
+    clearCacheNsps?: any[]
+  }
   export interface Pager {
     rows: number
     last: number


### PR DESCRIPTION
This pull request introduces a new mechanism for handling MySQL transactions safely with cache consistency, primarily by adding the `MysqlSafeTransaction` class and enhancing cache invalidation logic to support transactional safety. The changes ensure that cache invalidation is deferred until after a successful transaction commit, preventing stale data issues in the presence of rollbacks. There are also related adjustments to the `MysqlCache` class and the public API, as well as a new test/demo for the safe transaction feature.

**Safe Transaction & Cache Consistency Improvements:**

* Introduced the `MysqlSafeTransaction` class, which wraps transactional operations and defers cache invalidation until after a successful commit, using a new mechanism to collect cache namespaces to clear during the transaction. (`src/components/MysqlSafeTransaction.ts`)
* Updated the `CoaMysql.Transaction` type to include `__isSafeTransaction` and `clearCacheNsps` properties, enabling the identification and handling of safe transactions throughout the codebase. (`src/typings.ts`)
* Enhanced the `MysqlCache` class so that all cache invalidation operations (`deleteCache` and related methods) are aware of safe transactions: if a safe transaction is detected, cache invalidation is deferred and the cache namespaces are collected for later deletion. (`src/services/MysqlCache.ts`) [[1]](diffhunk://#diff-7004bf4f4b02cd7806c7bd4d27d8621ea52970a3b5888e94709419921b554d86L18-R59) [[2]](diffhunk://#diff-7004bf4f4b02cd7806c7bd4d27d8621ea52970a3b5888e94709419921b554d86L158-R163) [[3]](diffhunk://#diff-7004bf4f4b02cd7806c7bd4d27d8621ea52970a3b5888e94709419921b554d86L172-R179)

**Cache Read Behavior Adjustments:**

* Modified all cache read methods in `MysqlCache` to bypass Redis caching when inside a safe transaction, ensuring that reads within a transaction always reflect the most current database state. (`src/services/MysqlCache.ts`) [[1]](diffhunk://#diff-7004bf4f4b02cd7806c7bd4d27d8621ea52970a3b5888e94709419921b554d86L69-R77) [[2]](diffhunk://#diff-7004bf4f4b02cd7806c7bd4d27d8621ea52970a3b5888e94709419921b554d86L91-R129)

**API and Test Updates:**

* Updated the public API exports to include `MysqlSafeTransaction` and reorganized export order for clarity. (`src/index.ts`)
* Added a new test/demo file `demoSafeTransaction.ts` to illustrate and validate the usage of the new safe transaction mechanism. (`src/test/demoSafeTransaction.ts`)

**Minor Refactoring:**

* Minor import order adjustment in `MysqlBin.ts` for consistency. (`src/libs/MysqlBin.ts`)